### PR TITLE
Redesign wallet state to support new settlement redesign

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -26,9 +26,9 @@ describe("Populating Accounts", () => {
       const accountId = renegade.registerAccount(keychain);
       await renegade.initializeAccount(accountId);
 
-      // Assert that accountId = uuidV4(keccak256(pk_view)[-16:])
+      // Assert that accountId = uuidV4(keccak256(pk_root)[-16:])
       const publicKeyHash = new Uint8Array(
-        keccak256(Buffer.from(keychain.keyHierarchy.view.publicKey.buffer)),
+        keccak256(Buffer.from(keychain.keyHierarchy.root.publicKey.buffer)),
       );
       expect(accountId).toEqual(uuid.v4({ random: publicKeyHash.slice(-16) }));
 

--- a/__tests__/keychain.test.ts
+++ b/__tests__/keychain.test.ts
@@ -11,7 +11,7 @@ import { RENEGADE_TEST_DIR, executeTestWithCleanup } from "./utils";
  * @param keychain2 The second Keychain to compare.
  */
 function expectNoCommonKeypairs(keychain1: Keychain, keychain2: Keychain) {
-  for (const key of ["root", "match", "settle", "view"]) {
+  for (const key of ["root", "match", "settle"]) {
     const keypair1 = keychain1.keyHierarchy[key];
     const keypair2 = keychain2.keyHierarchy[key];
     expect(keypair1.secretKey).not.toEqual(keypair2.secretKey);

--- a/__tests__/order.test.ts
+++ b/__tests__/order.test.ts
@@ -1,4 +1,4 @@
-import { Keychain, Order, Renegade, Token } from "../src";
+import { Keychain, Order, OrderId, Renegade, Token } from "../src";
 import { renegadeConfig } from "./utils";
 
 // Some test orders.
@@ -19,6 +19,29 @@ const order2 = new Order({
   price: 30000,
 });
 
+// Equality check for orders, ignoring the timestamp.
+function expectOrderEquality(order1: Order, order2: Order) {
+  expect(order1.orderId).toEqual(order2.orderId);
+  expect(order1.baseToken).toEqual(order2.baseToken);
+  expect(order1.quoteToken).toEqual(order2.quoteToken);
+  expect(order1.side).toEqual(order2.side);
+  expect(order1.type).toEqual(order2.type);
+  expect(order1.amount).toEqual(order2.amount);
+  expect(order1.minimumAmount).toEqual(order2.minimumAmount);
+  expect(order1.price).toEqual(order2.price);
+}
+
+// Equality check for a hashmap of orders, ignoring the timestamp.
+function expectOrdersEquality(
+  orders1: Record<OrderId, Order>,
+  orders2: Record<OrderId, Order>,
+) {
+  expect(Object.keys(orders1).sort()).toEqual(Object.keys(orders2).sort());
+  for (const orderId in orders1) {
+    expectOrderEquality(orders1[orderId], orders2[orderId]);
+  }
+}
+
 describe("Creating and Cancelling Orders", () => {
   test.concurrent(
     "Creating an order should result in the order being added to the Account's orders",
@@ -30,7 +53,7 @@ describe("Creating and Cancelling Orders", () => {
 
       // Create and submit the order.
       await renegade.placeOrder(accountId, order1);
-      expect(renegade.getOrders(accountId)).toEqual({
+      expectOrdersEquality(renegade.getOrders(accountId), {
         [order1.orderId]: order1,
       });
 
@@ -47,11 +70,15 @@ describe("Creating and Cancelling Orders", () => {
 
     // Create and submit the order.
     await renegade.placeOrder(accountId, order1);
-    expect(renegade.getOrders(accountId)).toEqual({ [order1.orderId]: order1 });
+    expectOrdersEquality(renegade.getOrders(accountId), {
+      [order1.orderId]: order1,
+    });
 
     // Modify the order.
     await renegade.modifyOrder(accountId, order1.orderId, order2);
-    expect(renegade.getOrders(accountId)).toEqual({ [order2.orderId]: order2 });
+    expectOrdersEquality(renegade.getOrders(accountId), {
+      [order2.orderId]: order2,
+    });
 
     // Teardown.
     await renegade.teardown();
@@ -67,18 +94,18 @@ describe("Creating and Cancelling Orders", () => {
 
       // Create and submit the orders.
       await renegade.placeOrder(accountId, order1);
-      expect(renegade.getOrders(accountId)).toEqual({
+      expectOrdersEquality(renegade.getOrders(accountId), {
         [order1.orderId]: order1,
       });
       await renegade.placeOrder(accountId, order2);
-      expect(renegade.getOrders(accountId)).toEqual({
+      expectOrdersEquality(renegade.getOrders(accountId), {
         [order1.orderId]: order1,
         [order2.orderId]: order2,
       });
 
       // Cancel one of the orders.
       await renegade.cancelOrder(accountId, order1.orderId);
-      expect(renegade.getOrders(accountId)).toEqual({
+      expectOrdersEquality(renegade.getOrders(accountId), {
         [order2.orderId]: order2,
       });
 
@@ -101,7 +128,7 @@ describe("Creating and Cancelling Orders", () => {
         .then(() => renegade.placeOrder(accountId1, order1))
         .then(() => renegade.placeOrder(accountId1, order2))
         .then(() =>
-          expect(renegade.getOrders(accountId1)).toEqual({
+          expectOrdersEquality(renegade.getOrders(accountId1), {
             [order1.orderId]: order1,
             [order2.orderId]: order2,
           }),
@@ -111,7 +138,7 @@ describe("Creating and Cancelling Orders", () => {
         .then(() => renegade.placeOrder(accountId2, order1))
         .then(() => renegade.placeOrder(accountId2, order2))
         .then(() =>
-          expect(renegade.getOrders(accountId2)).toEqual({
+          expectOrdersEquality(renegade.getOrders(accountId2), {
             [order1.orderId]: order1,
             [order2.orderId]: order2,
           }),

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -8,7 +8,8 @@ export const renegadeConfig: RenegadeConfig = {
   relayerHttpPort: 3000,
   relayerWsPort: 4000,
   useInsecureTransport: true,
-  verbose: true,
+  verbose: false,
+  taskDelay: 1000,
 };
 export const globalKeychain = new Keychain({
   skRoot: Buffer.from(

--- a/dist/account.d.ts
+++ b/dist/account.d.ts
@@ -1,6 +1,6 @@
 import { Balance, Fee, Keychain, Order, Token } from "./state";
 import { AccountId, BalanceId, FeeId, OrderId, TaskId } from "./types";
-import { TaskJob } from "./utils";
+import { RenegadeWs, TaskJob } from "./utils";
 /**
  * A Renegade Account, which is a thin wrapper over the Wallet abstraction. The
  * authoritative Wallet state is stored on-chain in StarkNet encrypted Wallet
@@ -150,4 +150,8 @@ export default class Account {
      * Getter for the AccountId.
      */
     get accountId(): AccountId;
+    /**
+     * Getter for the underlying RenegadeWs.
+     */
+    get ws(): RenegadeWs;
 }

--- a/dist/account.js
+++ b/dist/account.js
@@ -412,6 +412,12 @@ export default class Account {
         // Hack to force type conversion, as AccountId = WalletId.
         return this._wallet.walletId;
     }
+    /**
+     * Getter for the underlying RenegadeWs.
+     */
+    get ws() {
+        return this._ws;
+    }
 }
 __decorate([
     assertSynced

--- a/dist/irenegade.d.ts
+++ b/dist/irenegade.d.ts
@@ -1,5 +1,6 @@
 import { Balance, Fee, Keychain, Order, Token } from "./state";
 import { AccountId, BalanceId, CallbackId, Exchange, FeeId, OrderId, TaskId } from "./types";
+import { Priority } from "./utils";
 /**
  * Interface for Account-related functions (registration, initialization,
  * relayer delegation, etc.).
@@ -195,10 +196,11 @@ export interface IRenegadeStreaming {
      *
      * @param callback The callback to invoke when a new account event is received.
      * @param accountId The AccountId of the Account to register the callback for.
+     * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
      *
      * @throws {AccountNotRegistered} If the Account corresponding to this AccountId is not registered with the Renegade object.
      */
-    registerAccountCallback(callback: (message: string) => void, accountId: AccountId): Promise<CallbackId>;
+    registerAccountCallback(callback: (message: string) => void, accountId: AccountId, priority?: Priority): Promise<CallbackId>;
     /**
      * Register a callback to be invoked when a new price report is received.
      *
@@ -206,33 +208,38 @@ export interface IRenegadeStreaming {
      * @param exchange The Exchange to get price reports from.
      * @param baseToken The base Token to get price reports for.
      * @param quoteToken The quote Token to get price reports for.
+     * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
      */
-    registerPriceReportCallback(callback: (message: string) => void, exchange: Exchange, baseToken: Token, quoteToken: Token): Promise<CallbackId>;
+    registerPriceReportCallback(callback: (message: string) => void, exchange: Exchange, baseToken: Token, quoteToken: Token, priority?: Priority): Promise<CallbackId>;
     /**
      * Register a callback to be invoked when a task state transition is received.
      *
      * @param callback The callback to invoke when a new order book update is received.
      * @param taskId The ID of the task to register the callback for.
+     * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
      */
-    registerTaskCallback(callback: (message: string) => void, taskId: TaskId): Promise<CallbackId>;
+    registerTaskCallback(callback: (message: string) => void, taskId: TaskId, priority?: Priority): Promise<CallbackId>;
     /**
      * Register a callback to be invoked when a new order book update is received.
      *
      * @param callback The callback to invoke when a new order book update is received.
+     * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
      */
-    registerOrderBookCallback(callback: (message: string) => void): Promise<CallbackId>;
+    registerOrderBookCallback(callback: (message: string) => void, priority?: Priority): Promise<CallbackId>;
     /**
      * Register a callback to be invoked when a new network event is received.
      *
      * @param callback The callback to invoke when a new network event is received.
+     * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
      */
-    registerNetworkCallback(callback: (message: string) => void): Promise<CallbackId>;
+    registerNetworkCallback(callback: (message: string) => void, priority?: Priority): Promise<CallbackId>;
     /**
      * Register a callback to be invoked when a new MPC event is received.
      *
      * @param callback The callback to invoke when a new MPC event is received.
+     * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
      */
-    registerMpcCallback(callback: (message: string) => void): Promise<CallbackId>;
+    registerMpcCallback(callback: (message: string) => void, priority?: Priority): Promise<CallbackId>;
     /**
      * Release a previously-registered callback. If no other callback is
      * registered for the same topic, the topic will be unsubscribed from.

--- a/dist/renegade.d.ts
+++ b/dist/renegade.d.ts
@@ -1,6 +1,7 @@
 import { IRenegadeAccount, IRenegadeBalance, IRenegadeFees, IRenegadeInformation, IRenegadeStreaming, IRenegadeTrading } from "./irenegade";
 import { Balance, Fee, Keychain, Order, Token } from "./state";
 import { AccountId, BalanceId, CallbackId, Exchange, FeeId, OrderId, TaskId } from "./types";
+import { Priority } from "./utils";
 /**
  * Configuration parameters for initial Renegade object creation.
  */
@@ -81,12 +82,12 @@ export default class Renegade implements IRenegadeAccount, IRenegadeInformation,
     approveFee(accountId: AccountId, fee: Fee): Promise<void>;
     modifyFee(accountId: AccountId, oldFeeId: FeeId, newFee: Fee): Promise<void>;
     revokeFee(accountId: AccountId, feeId: FeeId): Promise<void>;
-    registerAccountCallback(callback: (message: string) => void, accountId: AccountId): Promise<CallbackId>;
-    registerPriceReportCallback(callback: (message: string) => void, exchange: Exchange, baseToken: Token, quoteToken: Token): Promise<CallbackId>;
-    registerTaskCallback(callback: (message: string) => void, taskId: TaskId): Promise<CallbackId>;
-    registerOrderBookCallback(callback: (message: string) => void): Promise<CallbackId>;
-    registerNetworkCallback(callback: (message: string) => void): Promise<CallbackId>;
-    registerMpcCallback(callback: (message: string) => void): Promise<CallbackId>;
+    registerAccountCallback(callback: (message: string) => void, accountId: AccountId, priority?: Priority): Promise<CallbackId>;
+    registerPriceReportCallback(callback: (message: string) => void, exchange: Exchange, baseToken: Token, quoteToken: Token, priority?: Priority): Promise<CallbackId>;
+    registerTaskCallback(callback: (message: string) => void, taskId: TaskId, priority?: Priority): Promise<CallbackId>;
+    registerOrderBookCallback(callback: (message: string) => void, priority?: Priority): Promise<CallbackId>;
+    registerNetworkCallback(callback: (message: string) => void, priority?: Priority): Promise<CallbackId>;
+    registerMpcCallback(callback: (message: string) => void, priority?: Priority): Promise<CallbackId>;
     releaseCallback(callbackId: CallbackId): Promise<void>;
     /**
      * The `task` object contains a subset of the Renegade API that contain

--- a/dist/renegade.d.ts
+++ b/dist/renegade.d.ts
@@ -10,6 +10,7 @@ export interface RenegadeConfig {
     relayerWsPort?: number;
     useInsecureTransport?: boolean;
     verbose?: boolean;
+    taskDelay?: number;
 }
 /**
  * The Renegade object is the primary method of interacting with the Renegade
@@ -19,6 +20,7 @@ export default class Renegade implements IRenegadeAccount, IRenegadeInformation,
     readonly relayerHttpUrl: string;
     readonly relayerWsUrl: string;
     private _verbose;
+    private _taskDelay;
     private _ws;
     private _registeredAccounts;
     private _isTornDown;

--- a/dist/renegade.js
+++ b/dist/renegade.js
@@ -73,6 +73,7 @@ export default class Renegade {
             config.relayerWsPort !== undefined ? config.relayerWsPort : 4000;
         config.useInsecureTransport = config.useInsecureTransport || false;
         this._verbose = config.verbose || false;
+        this._taskDelay = config.taskDelay || 0;
         // Construct the URLs and save them.
         if (config.relayerHostname === "localhost") {
             config.relayerHostname = "127.0.0.1";
@@ -163,6 +164,7 @@ export default class Renegade {
     }
     async awaitTaskCompletion(taskId) {
         await this._ws.awaitTaskCompletion(taskId);
+        await new Promise((resolve) => setTimeout(resolve, this._taskDelay));
     }
     async teardown() {
         for (const accountId in this._registeredAccounts) {

--- a/dist/renegade.js
+++ b/dist/renegade.js
@@ -289,23 +289,33 @@ export default class Renegade {
     // -------------------------------------
     // | IRenegadeStreaming Implementation |
     // -------------------------------------
-    async registerAccountCallback(callback, accountId) {
+    async registerAccountCallback(callback, accountId, priority) {
+        // We could directly register a callback with
+        // this._ws.registerAccountCallback(callback, ...), but this can lead to
+        // race conditions.
+        //
+        // Since each individual Account streams account events to update its
+        // internal balances, orders, and fees, directly registering an account
+        // callback with the Renegade websocket does not guarantee ordering of these
+        // messages.
+        //
+        // Instead, we hook directly into the Account stream.
         const account = this._lookupAccount(accountId);
-        return await this._ws.registerAccountCallback(callback, accountId, account.keychain);
+        return await account.ws.registerAccountCallback(callback, accountId, account.keychain, priority);
     }
-    async registerPriceReportCallback(callback, exchange, baseToken, quoteToken) {
-        return await this._ws.registerPriceReportCallback(callback, exchange, baseToken, quoteToken);
+    async registerPriceReportCallback(callback, exchange, baseToken, quoteToken, priority) {
+        return await this._ws.registerPriceReportCallback(callback, exchange, baseToken, quoteToken, priority);
     }
-    async registerTaskCallback(callback, taskId) {
-        return await this._ws.registerTaskCallback(callback, taskId);
+    async registerTaskCallback(callback, taskId, priority) {
+        return await this._ws.registerTaskCallback(callback, taskId, priority);
     }
-    registerOrderBookCallback(callback) {
+    registerOrderBookCallback(callback, priority) {
         unimplemented();
     }
-    registerNetworkCallback(callback) {
+    registerNetworkCallback(callback, priority) {
         unimplemented();
     }
-    registerMpcCallback(callback) {
+    registerMpcCallback(callback, priority) {
         unimplemented();
     }
     async releaseCallback(callbackId) {

--- a/dist/state/balance.d.ts
+++ b/dist/state/balance.d.ts
@@ -8,6 +8,7 @@ export default class Balance {
         mint: Token;
         amount: bigint;
     });
+    pack(): bigint[];
     serialize(): string;
     static deserialize(serializedBalance: any): Balance;
 }

--- a/dist/state/balance.js
+++ b/dist/state/balance.js
@@ -6,6 +6,9 @@ export default class Balance {
         this.mint = params.mint;
         this.amount = params.amount;
     }
+    pack() {
+        return [BigInt("0x" + this.mint.address), this.amount];
+    }
     serialize() {
         return `{
       "mint": "${this.mint.serialize()}",

--- a/dist/state/fee.d.ts
+++ b/dist/state/fee.d.ts
@@ -2,16 +2,17 @@ import { FeeId } from "../types";
 import Token from "./token";
 export default class Fee {
     readonly feeId: FeeId;
-    readonly pkSettle: bigint;
+    readonly recipientKey: bigint;
     readonly gasMint: Token;
     readonly gasAmount: bigint;
-    readonly percentFee: number;
+    readonly percentageFee: number;
     constructor(params: {
-        pkSettle: bigint;
+        recipientKey: bigint;
         gasMint: Token;
         gasAmount: bigint;
-        percentFee: number;
+        percentageFee: number;
     });
+    pack(): bigint[];
     serialize(): string;
     static deserialize(serializedFee: any): Fee;
 }

--- a/dist/state/fee.js
+++ b/dist/state/fee.js
@@ -1,27 +1,36 @@
 import * as uuid from "uuid";
 import Token from "./token";
+import { bigIntToLimbsLE } from "./utils";
 export default class Fee {
     constructor(params) {
         this.feeId = uuid.v4();
-        this.pkSettle = params.pkSettle;
+        this.recipientKey = params.recipientKey;
         this.gasMint = params.gasMint;
         this.gasAmount = params.gasAmount;
-        this.percentFee = params.percentFee;
+        this.percentageFee = params.percentageFee;
+    }
+    pack() {
+        return [
+            this.recipientKey,
+            BigInt("0x" + this.gasMint.address),
+            this.gasAmount,
+            BigInt(this.percentageFee),
+        ];
     }
     serialize() {
         return `{
-      "pk_settle": ${this.pkSettle},
-      "gas_mint": "${this.gasMint.serialize()}",
-      "gas_amount": ${this.gasAmount},
-      "percent_fee": ${this.percentFee}
+      "recipient_key": "${this.recipientKey}",
+      "gas_addr": "${this.gasMint.serialize()}",
+      "gas_amount": [${bigIntToLimbsLE(this.gasAmount).join(",")}],
+      "percentage_fee": ${this.percentageFee}
     }`.replace(/[\s\n]/g, "");
     }
     static deserialize(serializedFee) {
         return new Fee({
-            pkSettle: BigInt(serializedFee.pk_settle),
+            recipientKey: BigInt(serializedFee.pk_settle),
             gasMint: Token.deserialize(serializedFee.gas_mint),
             gasAmount: BigInt(serializedFee.gas_amount),
-            percentFee: serializedFee.percent_fee,
+            percentageFee: serializedFee.percent_fee,
         });
     }
 }

--- a/dist/state/keychain.d.ts
+++ b/dist/state/keychain.d.ts
@@ -1,19 +1,24 @@
 /// <reference types="node" />
+export declare const BASEPOINT_ORDER: bigint;
 declare class SigningKey {
     secretKey: Uint8Array;
     publicKey: Uint8Array;
     constructor(secretKey: Uint8Array);
     signMessage(message: Uint8Array): Uint8Array;
 }
+declare class IdentificationKey {
+    secretKey: Uint8Array;
+    publicKey: Uint8Array;
+    constructor(secretKey: Uint8Array);
+}
 /**
- * The KeyHierarchy contains the root, match, settle, and view keypairs for a
- * Renegade Account.
+ * The KeyHierarchy contains the root, match, and settlekeypairs for a Renegade
+ * Account.
  */
 interface KeyHierarchy {
     root: SigningKey;
-    match: SigningKey;
+    match: IdentificationKey;
     settle: SigningKey;
-    view: SigningKey;
 }
 /**
  * Options for creating a Keychain. If all options are undefined, then a random
@@ -30,11 +35,9 @@ interface KeychainOptions {
 export default class Keychain {
     static CREATE_SK_ROOT_MESSAGE: string;
     static CREATE_SK_MATCH_MESSAGE: string;
-    static CREATE_SK_SETTLE_MESSAGE: string;
-    static CREATE_SK_VIEW_MESSAGE: string;
     /**
-     * The full renegade key hierarchy, including root, match, settle, and view
-     * keypairs. Note that the Keychain class always contains all four secret
+     * The full renegade key hierarchy, including root, match, and settle
+     * keypairs. Note that the Keychain class always contains all three secret
      * keys; for delegation to non-super-relayers, we support delegation without
      * sk_root.
      */
@@ -72,7 +75,8 @@ export default class Keychain {
     /**
      * Serialize the keychain to a string. Note that @noble/ed25519 uses little
      * endian byte order for all EC points, so we reverse the byte order for big
-     * endian encodings.*
+     * endian encodings.
+     *
      * @param asBigEndian If true, the keys will be serialized in big endian byte order.
      * @returns The serialized keychain.
      */

--- a/dist/state/order.d.ts
+++ b/dist/state/order.d.ts
@@ -21,6 +21,7 @@ export default class Order {
         price?: number;
         timestamp?: number;
     });
+    pack(): bigint[];
     serialize(): string;
     static deserialize(serializedOrder: any): Order;
 }

--- a/dist/state/utils.d.ts
+++ b/dist/state/utils.d.ts
@@ -2,5 +2,5 @@
 export declare const RENEGADE_AUTH_HEADER = "renegade-auth";
 export declare const RENEGADE_AUTH_EXPIRATION_HEADER = "renegade-auth-expiration";
 export declare function generateId(data: Buffer): string;
-export declare function bigIntToLimbs(bigint: bigint): [bigint, bigint, bigint, bigint];
-export declare function limbsToBigInt(limbs: number[]): bigint;
+export declare function bigIntToLimbsLE(number: bigint, bitsPerLimb?: number, numLimbs?: number): bigint[];
+export declare function limbsToBigIntLE(limbs: (number | bigint)[], bitsPerLimb?: number): bigint;

--- a/dist/state/utils.js
+++ b/dist/state/utils.js
@@ -6,27 +6,23 @@ export function generateId(data) {
     const dataHash = new Uint8Array(keccak256(data));
     return uuid.v4({ random: dataHash.slice(-16) });
 }
-export function bigIntToLimbs(bigint) {
-    return [
-        bigint % 2n ** 32n,
-        (bigint >> 32n) % 2n ** 32n,
-        (bigint >> 64n) % 2n ** 32n,
-        (bigint >> 96n) % 2n ** 32n,
-    ];
+export function bigIntToLimbsLE(number, bitsPerLimb, numLimbs) {
+    bitsPerLimb = bitsPerLimb || 32;
+    numLimbs = numLimbs || 8;
+    if (number < 0n || number >= 2n ** BigInt(bitsPerLimb * numLimbs)) {
+        throw new Error("Invalid conversion of bigint to limbs: " + number);
+    }
+    const limbs = [];
+    for (let i = 0; i < numLimbs; i++) {
+        limbs.push((number >> BigInt(i * bitsPerLimb)) % 2n ** BigInt(bitsPerLimb));
+    }
+    return limbs;
 }
-export function limbsToBigInt(limbs) {
-    if (limbs.length === 0) {
-        return 0n;
+export function limbsToBigIntLE(limbs, bitsPerLimb) {
+    bitsPerLimb = bitsPerLimb || 32;
+    let number = 0n;
+    for (let i = 0; i < limbs.length; i++) {
+        number += BigInt(limbs[i]) * 2n ** BigInt(i * bitsPerLimb);
     }
-    else if (limbs.length === 1) {
-        return BigInt(limbs[0]);
-    }
-    else if (limbs.length !== 4) {
-        throw new Error(`Invalid limbs: ${limbs}`);
-    }
-    const limbsBigInt = limbs.map((limb) => BigInt(limb));
-    return (limbsBigInt[0] +
-        limbsBigInt[1] * 2n ** 32n +
-        limbsBigInt[2] * 2n ** 64n +
-        limbsBigInt[3] * 2n ** 96n);
+    return number;
 }

--- a/dist/state/wallet.d.ts
+++ b/dist/state/wallet.d.ts
@@ -9,15 +9,31 @@ export default class Wallet {
     readonly orders: Order[];
     readonly fees: Fee[];
     readonly keychain: Keychain;
-    readonly randomness: bigint;
+    readonly blinder: bigint;
+    readonly blindedPublicShares: bigint[];
+    readonly privateShares: bigint[];
     constructor(params: {
         id?: WalletId;
         balances: Balance[];
         orders: Order[];
         fees: Fee[];
         keychain: Keychain;
-        randomness: bigint;
+        blinder: bigint;
     });
+    packBalances(): bigint[];
+    packOrders(): bigint[];
+    packFees(): bigint[];
+    packKeychain(): bigint[];
+    packBlinder(): bigint[];
+    /**
+     * Generated the "packed" form of this wallet by concatenating the packed
+     * forms of each of its components.
+     */
+    packWallet(): bigint[];
+    /**
+     * Derive blinded public shares and private shares for the wallet.
+     */
+    deriveShares(): [bigint[], bigint[]];
     serialize(asBigEndian?: boolean): string;
     static deserialize(serializedWallet: any, asBigEndian?: boolean): Wallet;
 }

--- a/dist/state/wallet.js
+++ b/dist/state/wallet.js
@@ -2,26 +2,110 @@ import Balance from "./balance";
 import Fee from "./fee";
 import Keychain from "./keychain";
 import Order from "./order";
-import { bigIntToLimbs, generateId, limbsToBigInt } from "./utils";
+import { bigIntToLimbsLE, generateId, limbsToBigIntLE } from "./utils";
+// The maximum number of balances, orders, and fees that can be stored in a wallet
+const MAX_BALANCES = 5;
+const MAX_ORDERS = 5;
+const MAX_FEES = 2;
+// Number of secret shares to represent each of balances, orders, and fees
+const SHARES_PER_BALANCE = 2;
+const SHARES_PER_ORDER = 6;
+const SHARES_PER_FEE = 4;
+// The number of felt words to represent pk_root
+const NUM_ROOT_KEY_WORDS = 3;
+// The number of shares to represent the keychain. Equal to the number of shares
+// to represent pk_root, plus one for pk_match
+const SHARES_PER_KEYCHAIN = NUM_ROOT_KEY_WORDS + 1;
+// The total number of shares per wallet
+const SHARES_PER_WALLET = MAX_BALANCES * SHARES_PER_BALANCE +
+    MAX_ORDERS * SHARES_PER_ORDER +
+    MAX_FEES * SHARES_PER_FEE +
+    SHARES_PER_KEYCHAIN +
+    1;
 export default class Wallet {
     constructor(params) {
         this.walletId =
             params.id ||
-                generateId(Buffer.from(params.keychain.keyHierarchy.view.publicKey.buffer));
+                generateId(Buffer.from(params.keychain.keyHierarchy.root.publicKey.buffer));
         this.balances = params.balances;
         this.orders = params.orders;
         this.fees = params.fees;
         this.keychain = params.keychain;
-        this.randomness = params.randomness;
+        this.blinder = 0n; // params.blinder;
+        [this.blindedPublicShares, this.privateShares] = this.deriveShares();
+    }
+    packBalances() {
+        const packedBalances = this.balances.map((balance) => balance.pack());
+        const packedPadding = Array(MAX_BALANCES - this.balances.length).fill(Array(SHARES_PER_BALANCE).fill(0n));
+        return packedBalances.flat().concat(packedPadding.flat());
+    }
+    packOrders() {
+        const packedOrders = this.orders.map((order) => order.pack());
+        const packedPadding = Array(MAX_ORDERS - this.orders.length).fill(Array(SHARES_PER_ORDER).fill(0n));
+        return packedOrders.flat().concat(packedPadding.flat());
+    }
+    packFees() {
+        const packedFees = this.fees.map((fee) => fee.pack());
+        const packedPadding = Array(MAX_FEES - this.fees.length).fill(Array(SHARES_PER_FEE).fill(0n));
+        return packedFees.flat().concat(packedPadding.flat());
+    }
+    packKeychain() {
+        const pkRoot = BigInt("0x" +
+            Buffer.from(this.keychain.keyHierarchy.root.publicKey)
+                .reverse()
+                .toString("hex"));
+        const pkMatch = BigInt("0x" +
+            Buffer.from(this.keychain.keyHierarchy.match.publicKey)
+                .reverse()
+                .toString("hex"));
+        const packedPkRoot = [
+            pkRoot % 2n ** 126n,
+            (pkRoot >> 126n) % 2n ** 126n,
+            (pkRoot >> 252n) % 2n ** 126n,
+        ];
+        const packedPkMatch = [pkMatch];
+        return packedPkRoot.concat(packedPkMatch);
+    }
+    packBlinder() {
+        return [this.blinder];
+    }
+    /**
+     * Generated the "packed" form of this wallet by concatenating the packed
+     * forms of each of its components.
+     */
+    packWallet() {
+        return this.packBalances()
+            .concat(this.packOrders())
+            .concat(this.packFees())
+            .concat(this.packKeychain())
+            .concat(this.packBlinder());
+    }
+    /**
+     * Derive blinded public shares and private shares for the wallet.
+     */
+    deriveShares() {
+        const packedWallet = this.packWallet();
+        const publicShares = packedWallet;
+        const privateShares = Array(packedWallet.length).fill(0n);
+        const blindedPublicShares = publicShares;
+        if (blindedPublicShares.length !== SHARES_PER_WALLET ||
+            privateShares.length !== SHARES_PER_WALLET) {
+            throw new Error("Invalid number of shares generated");
+        }
+        return [blindedPublicShares, privateShares];
     }
     serialize(asBigEndian) {
+        const serializedBlindedPublicShares = this.blindedPublicShares.map((share) => "[" + bigIntToLimbsLE(share).join(",") + "]");
+        const serializedPrivateShares = this.privateShares.map((share) => "[" + bigIntToLimbsLE(share).join(",") + "]");
         return `{
       "id": "${this.walletId}",
       "balances": [${this.balances.map((b) => b.serialize()).join(",")}],
       "orders": [${this.orders.map((o) => o.serialize()).join(",")}],
       "fees": [${this.fees.map((f) => f.serialize()).join(",")}],
       "key_chain": ${this.keychain.serialize(asBigEndian)},
-      "randomness": [${bigIntToLimbs(this.randomness).join(",")}]
+      "blinder": [${bigIntToLimbsLE(this.blinder).join(",")}],
+      "blinded_public_shares": [${serializedBlindedPublicShares.join(",")}],
+      "private_shares": [${serializedPrivateShares.join(",")}]
     }`.replace(/[\s\n]/g, "");
     }
     static deserialize(serializedWallet, asBigEndian) {
@@ -30,7 +114,7 @@ export default class Wallet {
         const orders = serializedWallet.orders.map((o) => Order.deserialize(o));
         const fees = serializedWallet.fees.map((f) => Fee.deserialize(f));
         const keychain = Keychain.deserialize(serializedWallet.key_chain, asBigEndian);
-        const randomness = limbsToBigInt(serializedWallet.randomness);
-        return new Wallet({ id, balances, orders, fees, keychain, randomness });
+        const blinder = limbsToBigIntLE(serializedWallet.blinder);
+        return new Wallet({ id, balances, orders, fees, keychain, blinder });
     }
 }

--- a/dist/utils/index.d.ts
+++ b/dist/utils/index.d.ts
@@ -1,6 +1,7 @@
 import { Keychain, Token } from "../state";
 import { AccountId, CallbackId, Exchange, TaskId } from "../types";
 export type TaskJob<R> = Promise<[TaskId, Promise<R>]>;
+export type Priority = number;
 export declare function unimplemented(): never;
 export declare class RenegadeWs {
     private _ws;
@@ -40,10 +41,10 @@ export declare class RenegadeWs {
      * @param taskId The UUID of the task to await.
      */
     awaitTaskCompletion(taskId: TaskId): Promise<void>;
-    registerAccountCallback(callback: (message: string) => void, accountId: AccountId, keychain: Keychain): Promise<CallbackId>;
-    registerPriceReportCallback(callback: (message: string) => void, exchange: Exchange, baseToken: Token, quoteToken: Token): Promise<CallbackId>;
-    registerTaskCallback(callback: (message: string) => void, taskId: TaskId): Promise<CallbackId>;
-    _registerCallbackWithTopic(callback: (message: string) => void, topic: string, keychain?: Keychain): Promise<CallbackId>;
+    registerAccountCallback(callback: (message: string) => void, accountId: AccountId, keychain: Keychain, priority?: Priority): Promise<CallbackId>;
+    registerPriceReportCallback(callback: (message: string) => void, exchange: Exchange, baseToken: Token, quoteToken: Token, priority?: Priority): Promise<CallbackId>;
+    registerTaskCallback(callback: (message: string) => void, taskId: TaskId, priority?: Priority): Promise<CallbackId>;
+    _registerCallbackWithTopic(callback: (message: string) => void, topic: string, keychain?: Keychain, priority?: Priority): Promise<CallbackId>;
     releaseCallback(callbackId: CallbackId): Promise<void>;
     teardown(): void;
 }

--- a/src/account.ts
+++ b/src/account.ts
@@ -471,4 +471,11 @@ export default class Account {
     // Hack to force type conversion, as AccountId = WalletId.
     return this._wallet.walletId as string as AccountId;
   }
+
+  /**
+   * Getter for the underlying RenegadeWs.
+   */
+  get ws(): RenegadeWs {
+    return this._ws;
+  }
 }

--- a/src/irenegade.ts
+++ b/src/irenegade.ts
@@ -8,6 +8,7 @@ import {
   OrderId,
   TaskId,
 } from "./types";
+import { Priority } from "./utils";
 
 // ----------------------
 // | Account Management |
@@ -242,12 +243,14 @@ export interface IRenegadeStreaming {
    *
    * @param callback The callback to invoke when a new account event is received.
    * @param accountId The AccountId of the Account to register the callback for.
+   * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
    *
    * @throws {AccountNotRegistered} If the Account corresponding to this AccountId is not registered with the Renegade object.
    */
   registerAccountCallback(
     callback: (message: string) => void,
     accountId: AccountId,
+    priority?: Priority,
   ): Promise<CallbackId>;
   /**
    * Register a callback to be invoked when a new price report is received.
@@ -256,45 +259,57 @@ export interface IRenegadeStreaming {
    * @param exchange The Exchange to get price reports from.
    * @param baseToken The base Token to get price reports for.
    * @param quoteToken The quote Token to get price reports for.
+   * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
    */
   registerPriceReportCallback(
     callback: (message: string) => void,
     exchange: Exchange,
     baseToken: Token,
     quoteToken: Token,
+    priority?: Priority,
   ): Promise<CallbackId>;
   /**
    * Register a callback to be invoked when a task state transition is received.
    *
    * @param callback The callback to invoke when a new order book update is received.
    * @param taskId The ID of the task to register the callback for.
+   * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
    */
   registerTaskCallback(
     callback: (message: string) => void,
     taskId: TaskId,
+    priority?: Priority,
   ): Promise<CallbackId>;
   /**
    * Register a callback to be invoked when a new order book update is received.
    *
    * @param callback The callback to invoke when a new order book update is received.
+   * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
    */
   registerOrderBookCallback(
     callback: (message: string) => void,
+    priority?: Priority,
   ): Promise<CallbackId>;
   /**
    * Register a callback to be invoked when a new network event is received.
    *
    * @param callback The callback to invoke when a new network event is received.
+   * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
    */
   registerNetworkCallback(
     callback: (message: string) => void,
+    priority?: Priority,
   ): Promise<CallbackId>;
   /**
    * Register a callback to be invoked when a new MPC event is received.
    *
    * @param callback The callback to invoke when a new MPC event is received.
+   * @param priority The priority of the callback. Higher priority callbacks will be invoked before lower priority callbacks.
    */
-  registerMpcCallback(callback: (message: string) => void): Promise<CallbackId>;
+  registerMpcCallback(
+    callback: (message: string) => void,
+    priority?: Priority,
+  ): Promise<CallbackId>;
   /**
    * Release a previously-registered callback. If no other callback is
    * registered for the same topic, the topic will be unsubscribed from.

--- a/src/renegade.ts
+++ b/src/renegade.ts
@@ -56,6 +56,9 @@ export interface RenegadeConfig {
   useInsecureTransport?: boolean;
   // Whether to print verbose output to the console.
   verbose?: boolean;
+  // Number of milliseconds to sleep before returning from any task. Useful for
+  // testing under load, when websocket messages may be buffered.
+  taskDelay?: number;
 }
 
 /**
@@ -81,6 +84,8 @@ export default class Renegade
   public readonly relayerWsUrl: string;
   // Print verbose output.
   private _verbose: boolean;
+  // Number of milliseconds to sleep before returning from any task.
+  private _taskDelay: number;
   // The WebSocket connection to the relayer.
   private _ws: RenegadeWs;
   // All Accounts that have been registered with the Renegade object.
@@ -104,6 +109,7 @@ export default class Renegade
       config.relayerWsPort !== undefined ? config.relayerWsPort : 4000;
     config.useInsecureTransport = config.useInsecureTransport || false;
     this._verbose = config.verbose || false;
+    this._taskDelay = config.taskDelay || 0;
     // Construct the URLs and save them.
     if (config.relayerHostname === "localhost") {
       config.relayerHostname = "127.0.0.1";
@@ -239,6 +245,7 @@ export default class Renegade
   @assertNotTornDown
   async awaitTaskCompletion(taskId: TaskId): Promise<void> {
     await this._ws.awaitTaskCompletion(taskId);
+    await new Promise((resolve) => setTimeout(resolve, this._taskDelay));
   }
 
   async teardown(): Promise<void> {

--- a/src/state/balance.ts
+++ b/src/state/balance.ts
@@ -14,6 +14,10 @@ export default class Balance {
     this.amount = params.amount;
   }
 
+  pack(): bigint[] {
+    return [BigInt("0x" + this.mint.address), this.amount];
+  }
+
   serialize(): string {
     return `{
       "mint": "${this.mint.serialize()}",

--- a/src/state/fee.ts
+++ b/src/state/fee.ts
@@ -2,41 +2,51 @@ import * as uuid from "uuid";
 
 import { FeeId } from "../types";
 import Token from "./token";
+import { bigIntToLimbsLE } from "./utils";
 
 export default class Fee {
   public readonly feeId: FeeId;
-  public readonly pkSettle: bigint;
+  public readonly recipientKey: bigint;
   public readonly gasMint: Token;
   public readonly gasAmount: bigint;
-  public readonly percentFee: number;
+  public readonly percentageFee: number;
   constructor(params: {
-    pkSettle: bigint;
+    recipientKey: bigint;
     gasMint: Token;
     gasAmount: bigint;
-    percentFee: number;
+    percentageFee: number;
   }) {
     this.feeId = uuid.v4() as FeeId;
-    this.pkSettle = params.pkSettle;
+    this.recipientKey = params.recipientKey;
     this.gasMint = params.gasMint;
     this.gasAmount = params.gasAmount;
-    this.percentFee = params.percentFee;
+    this.percentageFee = params.percentageFee;
+  }
+
+  pack(): bigint[] {
+    return [
+      this.recipientKey,
+      BigInt("0x" + this.gasMint.address),
+      this.gasAmount,
+      BigInt(this.percentageFee),
+    ];
   }
 
   serialize(): string {
     return `{
-      "pk_settle": ${this.pkSettle},
-      "gas_mint": "${this.gasMint.serialize()}",
-      "gas_amount": ${this.gasAmount},
-      "percent_fee": ${this.percentFee}
+      "recipient_key": "${this.recipientKey}",
+      "gas_addr": "${this.gasMint.serialize()}",
+      "gas_amount": [${bigIntToLimbsLE(this.gasAmount).join(",")}],
+      "percentage_fee": ${this.percentageFee}
     }`.replace(/[\s\n]/g, "");
   }
 
   static deserialize(serializedFee: any): Fee {
     return new Fee({
-      pkSettle: BigInt(serializedFee.pk_settle),
+      recipientKey: BigInt(serializedFee.pk_settle),
       gasMint: Token.deserialize(serializedFee.gas_mint),
       gasAmount: BigInt(serializedFee.gas_amount),
-      percentFee: serializedFee.percent_fee,
+      percentageFee: serializedFee.percent_fee,
     });
   }
 }

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -9,30 +9,31 @@ export function generateId(data: Buffer): string {
   return uuid.v4({ random: dataHash.slice(-16) });
 }
 
-export function bigIntToLimbs(
-  bigint: bigint,
-): [bigint, bigint, bigint, bigint] {
-  return [
-    bigint % 2n ** 32n,
-    (bigint >> 32n) % 2n ** 32n,
-    (bigint >> 64n) % 2n ** 32n,
-    (bigint >> 96n) % 2n ** 32n,
-  ];
+export function bigIntToLimbsLE(
+  number: bigint,
+  bitsPerLimb?: number,
+  numLimbs?: number,
+): bigint[] {
+  bitsPerLimb = bitsPerLimb || 32;
+  numLimbs = numLimbs || 8;
+  if (number < 0n || number >= 2n ** BigInt(bitsPerLimb * numLimbs)) {
+    throw new Error("Invalid conversion of bigint to limbs: " + number);
+  }
+  const limbs = [];
+  for (let i = 0; i < numLimbs; i++) {
+    limbs.push((number >> BigInt(i * bitsPerLimb)) % 2n ** BigInt(bitsPerLimb));
+  }
+  return limbs;
 }
 
-export function limbsToBigInt(limbs: number[]): bigint {
-  if (limbs.length === 0) {
-    return 0n;
-  } else if (limbs.length === 1) {
-    return BigInt(limbs[0]);
-  } else if (limbs.length !== 4) {
-    throw new Error(`Invalid limbs: ${limbs}`);
+export function limbsToBigIntLE(
+  limbs: (number | bigint)[],
+  bitsPerLimb?: number,
+): bigint {
+  bitsPerLimb = bitsPerLimb || 32;
+  let number = 0n;
+  for (let i = 0; i < limbs.length; i++) {
+    number += BigInt(limbs[i]) * 2n ** BigInt(i * bitsPerLimb);
   }
-  const limbsBigInt = limbs.map((limb) => BigInt(limb));
-  return (
-    limbsBigInt[0] +
-    limbsBigInt[1] * 2n ** 32n +
-    limbsBigInt[2] * 2n ** 64n +
-    limbsBigInt[3] * 2n ** 96n
-  );
+  return number;
 }

--- a/src/state/wallet.ts
+++ b/src/state/wallet.ts
@@ -3,7 +3,31 @@ import Balance from "./balance";
 import Fee from "./fee";
 import Keychain from "./keychain";
 import Order from "./order";
-import { bigIntToLimbs, generateId, limbsToBigInt } from "./utils";
+import { bigIntToLimbsLE, generateId, limbsToBigIntLE } from "./utils";
+
+// The maximum number of balances, orders, and fees that can be stored in a wallet
+const MAX_BALANCES = 5;
+const MAX_ORDERS = 5;
+const MAX_FEES = 2;
+
+// Number of secret shares to represent each of balances, orders, and fees
+const SHARES_PER_BALANCE = 2;
+const SHARES_PER_ORDER = 6;
+const SHARES_PER_FEE = 4;
+
+// The number of felt words to represent pk_root
+const NUM_ROOT_KEY_WORDS = 3;
+
+// The number of shares to represent the keychain. Equal to the number of shares
+// to represent pk_root, plus one for pk_match
+const SHARES_PER_KEYCHAIN = NUM_ROOT_KEY_WORDS + 1;
+// The total number of shares per wallet
+const SHARES_PER_WALLET =
+  MAX_BALANCES * SHARES_PER_BALANCE +
+  MAX_ORDERS * SHARES_PER_ORDER +
+  MAX_FEES * SHARES_PER_FEE +
+  SHARES_PER_KEYCHAIN +
+  1;
 
 export default class Wallet {
   public readonly walletId: WalletId;
@@ -11,35 +35,126 @@ export default class Wallet {
   public readonly orders: Order[];
   public readonly fees: Fee[];
   public readonly keychain: Keychain;
-  public readonly randomness: bigint;
+  public readonly blinder: bigint;
+  public readonly blindedPublicShares: bigint[];
+  public readonly privateShares: bigint[];
   constructor(params: {
     id?: WalletId;
     balances: Balance[];
     orders: Order[];
     fees: Fee[];
     keychain: Keychain;
-    randomness: bigint;
+    blinder: bigint;
   }) {
     this.walletId =
       params.id ||
       (generateId(
-        Buffer.from(params.keychain.keyHierarchy.view.publicKey.buffer),
+        Buffer.from(params.keychain.keyHierarchy.root.publicKey.buffer),
       ) as WalletId);
     this.balances = params.balances;
     this.orders = params.orders;
     this.fees = params.fees;
     this.keychain = params.keychain;
-    this.randomness = params.randomness;
+    this.blinder = 0n; // params.blinder;
+    [this.blindedPublicShares, this.privateShares] = this.deriveShares();
+  }
+
+  packBalances(): bigint[] {
+    const packedBalances = this.balances.map((balance) => balance.pack());
+    const packedPadding = Array(MAX_BALANCES - this.balances.length).fill(
+      Array(SHARES_PER_BALANCE).fill(0n),
+    );
+    return packedBalances.flat().concat(packedPadding.flat());
+  }
+
+  packOrders(): bigint[] {
+    const packedOrders = this.orders.map((order) => order.pack());
+    const packedPadding = Array(MAX_ORDERS - this.orders.length).fill(
+      Array(SHARES_PER_ORDER).fill(0n),
+    );
+    return packedOrders.flat().concat(packedPadding.flat());
+  }
+
+  packFees(): bigint[] {
+    const packedFees = this.fees.map((fee) => fee.pack());
+    const packedPadding = Array(MAX_FEES - this.fees.length).fill(
+      Array(SHARES_PER_FEE).fill(0n),
+    );
+    return packedFees.flat().concat(packedPadding.flat());
+  }
+
+  packKeychain(): bigint[] {
+    const pkRoot = BigInt(
+      "0x" +
+        Buffer.from(this.keychain.keyHierarchy.root.publicKey)
+          .reverse()
+          .toString("hex"),
+    );
+    const pkMatch = BigInt(
+      "0x" +
+        Buffer.from(this.keychain.keyHierarchy.match.publicKey)
+          .reverse()
+          .toString("hex"),
+    );
+    const packedPkRoot = [
+      pkRoot % 2n ** 126n,
+      (pkRoot >> 126n) % 2n ** 126n,
+      (pkRoot >> 252n) % 2n ** 126n,
+    ];
+    const packedPkMatch = [pkMatch];
+    return packedPkRoot.concat(packedPkMatch);
+  }
+
+  packBlinder(): bigint[] {
+    return [this.blinder];
+  }
+
+  /**
+   * Generated the "packed" form of this wallet by concatenating the packed
+   * forms of each of its components.
+   */
+  packWallet(): bigint[] {
+    return this.packBalances()
+      .concat(this.packOrders())
+      .concat(this.packFees())
+      .concat(this.packKeychain())
+      .concat(this.packBlinder());
+  }
+
+  /**
+   * Derive blinded public shares and private shares for the wallet.
+   */
+  deriveShares(): [bigint[], bigint[]] {
+    const packedWallet = this.packWallet();
+    const publicShares = packedWallet;
+    const privateShares = Array(packedWallet.length).fill(0n);
+
+    const blindedPublicShares = publicShares;
+    if (
+      blindedPublicShares.length !== SHARES_PER_WALLET ||
+      privateShares.length !== SHARES_PER_WALLET
+    ) {
+      throw new Error("Invalid number of shares generated");
+    }
+    return [blindedPublicShares, privateShares];
   }
 
   serialize(asBigEndian?: boolean): string {
+    const serializedBlindedPublicShares = this.blindedPublicShares.map(
+      (share) => "[" + bigIntToLimbsLE(share).join(",") + "]",
+    );
+    const serializedPrivateShares = this.privateShares.map(
+      (share) => "[" + bigIntToLimbsLE(share).join(",") + "]",
+    );
     return `{
       "id": "${this.walletId}",
       "balances": [${this.balances.map((b) => b.serialize()).join(",")}],
       "orders": [${this.orders.map((o) => o.serialize()).join(",")}],
       "fees": [${this.fees.map((f) => f.serialize()).join(",")}],
       "key_chain": ${this.keychain.serialize(asBigEndian)},
-      "randomness": [${bigIntToLimbs(this.randomness).join(",")}]
+      "blinder": [${bigIntToLimbsLE(this.blinder).join(",")}],
+      "blinded_public_shares": [${serializedBlindedPublicShares.join(",")}],
+      "private_shares": [${serializedPrivateShares.join(",")}]
     }`.replace(/[\s\n]/g, "");
   }
 
@@ -56,7 +171,7 @@ export default class Wallet {
       serializedWallet.key_chain,
       asBigEndian,
     );
-    const randomness = limbsToBigInt(serializedWallet.randomness);
-    return new Wallet({ id, balances, orders, fees, keychain, randomness });
+    const blinder = limbsToBigIntLE(serializedWallet.blinder);
+    return new Wallet({ id, balances, orders, fees, keychain, blinder });
   }
 }


### PR DESCRIPTION
### Purpose

Modify the `Wallet` abstraction and all communication with the relayer to support the new settlement design. This includes serialization and packing of all `Wallet` values into vectors of `blinded_public_shares` and `private_shares`.

Note that the current secret-sharing scheme is completely insecure; we don't properly derive randomness hierarchies, and just use zeroes for the `private_shares`. This PR is merely meant for API-compatibility with the new relayer.