### PR TITLE
testing: Add tests for the internal matching engine

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
-    project: './tsconfig.json'
+    project: './tsconfig.lint.json'
   },
   rules: {
   }

--- a/__tests__/callback.test.ts
+++ b/__tests__/callback.test.ts
@@ -5,7 +5,7 @@ describe("Events Streaming", () => {
   test.concurrent("Streaming price reports should work", async () => {
     const renegade = new Renegade(renegadeConfig);
     let receivedAnyMessage = false;
-    const callback = (message: string) => {
+    const callback = () => {
       receivedAnyMessage = true;
     };
     renegade.registerPriceReportCallback(

--- a/__tests__/deposit.test.ts
+++ b/__tests__/deposit.test.ts
@@ -11,11 +11,11 @@ function expectBalances(
   expectedBalances: Record<string, bigint>,
 ) {
   const expectedBalancesAddresses = {};
-  for (let ticker of Object.keys(expectedBalances)) {
+  for (const ticker of Object.keys(expectedBalances)) {
     const address = new Token({ ticker }).address;
     expectedBalancesAddresses[address] = expectedBalances[ticker];
   }
-  for (let balance of Object.values(balances)) {
+  for (const balance of Object.values(balances)) {
     expect(balance.amount).toEqual(
       expectedBalancesAddresses[balance.mint.address],
     );
@@ -72,14 +72,12 @@ describe("Depositing and Withdrawing Tokens", () => {
       // Withdraw WETH.
       await renegade.withdraw(accountId, new Token({ ticker: "WETH" }), 1000n);
       expectBalances(renegade.getBalances(accountId), {
-        WETH: 0n,
         USDC: 2000n,
       });
 
       // Withdraw USDC.
       await renegade.withdraw(accountId, new Token({ ticker: "USDC" }), 500n);
       expectBalances(renegade.getBalances(accountId), {
-        WETH: 0n,
         USDC: 1500n,
       });
 

--- a/__tests__/match.test.ts
+++ b/__tests__/match.test.ts
@@ -1,0 +1,215 @@
+import { AccountId, Keychain, Order, Renegade, Token } from "../src";
+import { expectOrdersEquality, renegadeConfig } from "./utils";
+
+async function setupMatchingAccounts(
+  renegade: Renegade,
+  orderBuy: Order,
+  orderSell: Order,
+  depositAmountBase: bigint,
+  depositAmountQuote: bigint,
+): Promise<[AccountId, AccountId]> {
+  // Get account IDs.
+  const accountIdBuy = renegade.registerAccount(new Keychain());
+  const accountIdSell = renegade.registerAccount(new Keychain());
+
+  // Create and submit the orders.
+  const promiseBuy = renegade
+    .initializeAccount(accountIdBuy)
+    .then(() =>
+      renegade.deposit(accountIdBuy, orderBuy.quoteToken, depositAmountQuote),
+    )
+    .then(() => renegade.placeOrder(accountIdBuy, orderBuy))
+    .then(() =>
+      expectOrdersEquality(renegade.getOrders(accountIdBuy), {
+        [orderBuy.orderId]: orderBuy,
+      }),
+    );
+  const promiseSell = renegade
+    .initializeAccount(accountIdSell)
+    .then(() =>
+      renegade.deposit(accountIdSell, orderSell.baseToken, depositAmountBase),
+    )
+    .then(() => renegade.placeOrder(accountIdSell, orderSell))
+    .then(() =>
+      expectOrdersEquality(renegade.getOrders(accountIdSell), {
+        [orderSell.orderId]: orderSell,
+      }),
+    );
+
+  // Await until orders have been confirmed onchain.
+  await Promise.all([promiseBuy, promiseSell]);
+  return [accountIdBuy, accountIdSell];
+}
+
+async function blockUntilUpdate(
+  renegade: Renegade,
+  accountId: AccountId,
+): Promise<void> {
+  return new Promise((resolve) => {
+    console.log("registering callback");
+    renegade.registerAccountCallback(() => {
+      console.log(`received update for ${accountId}`);
+      resolve();
+    }, accountId);
+  });
+}
+
+describe("Internal Order Matching", () => {
+  test.concurrent(
+    "Two matching orders from different accounts should match",
+    async () => {
+      // Set up accounts.
+      const renegade = new Renegade(renegadeConfig);
+      const orderBuy = new Order({
+        baseToken: new Token({ ticker: "WETH" }),
+        quoteToken: new Token({ ticker: "USDC" }),
+        side: "buy",
+        type: "midpoint",
+        amount: BigInt(5),
+      });
+      const orderSell = new Order({
+        baseToken: new Token({ ticker: "WETH" }),
+        quoteToken: new Token({ ticker: "USDC" }),
+        side: "sell",
+        type: "midpoint",
+        amount: BigInt(2),
+      });
+      const amountBase = BigInt(50);
+      const amountQuote = BigInt(1_000_000);
+      const [accountIdBuy, accountIdSell] = await setupMatchingAccounts(
+        renegade,
+        orderBuy,
+        orderSell,
+        amountBase,
+        amountQuote,
+      );
+
+      // Await until both wallets have an update.
+      await Promise.all([
+        blockUntilUpdate(renegade, accountIdBuy),
+        blockUntilUpdate(renegade, accountIdSell),
+      ]);
+
+      // Assert that the orders were matched.
+      const orderRemaining = new Order({
+        id: orderBuy.orderId,
+        baseToken: new Token({ ticker: "WETH" }),
+        quoteToken: new Token({ ticker: "USDC" }),
+        side: "buy",
+        type: "midpoint",
+        amount: BigInt(3),
+      });
+      expectOrdersEquality(renegade.getOrders(accountIdBuy), {
+        [orderRemaining.orderId]: orderRemaining,
+      });
+      expectOrdersEquality(renegade.getOrders(accountIdSell), {});
+
+      // Assert that the balances were updated.
+      for (const balance of Object.values(renegade.getBalances(accountIdBuy))) {
+        if (balance.mint.address === orderBuy.baseToken.address) {
+          expect(balance.amount).toBe(
+            orderBuy.amount < orderSell.amount
+              ? orderBuy.amount
+              : orderSell.amount,
+          );
+        } else if (balance.mint.address === orderBuy.quoteToken.address) {
+          expect(balance.amount).toBeLessThan(amountQuote);
+        }
+      }
+      for (const balance of Object.values(
+        renegade.getBalances(accountIdSell),
+      )) {
+        if (balance.mint.address === orderSell.baseToken.address) {
+          expect(balance.amount).toBe(
+            amountBase -
+              (orderBuy.amount < orderSell.amount
+                ? orderBuy.amount
+                : orderSell.amount),
+          );
+        } else if (balance.mint.address === orderSell.quoteToken.address) {
+          expect(balance.amount).toBeGreaterThan(0);
+        }
+      }
+
+      // Teardown.
+      await renegade.teardown();
+    },
+  );
+
+  test.concurrent(
+    "A second match should be possible after the first match",
+    async () => {
+      // Set up accounts.
+      const renegade = new Renegade(renegadeConfig);
+      const orderBuy = new Order({
+        baseToken: new Token({ ticker: "WBTC" }),
+        quoteToken: new Token({ ticker: "USDC" }),
+        side: "buy",
+        type: "midpoint",
+        amount: BigInt(1),
+      });
+      const orderSell = new Order({
+        baseToken: new Token({ ticker: "WBTC" }),
+        quoteToken: new Token({ ticker: "USDC" }),
+        side: "sell",
+        type: "midpoint",
+        amount: BigInt(5),
+      });
+      const amountBase = BigInt(50);
+      const amountQuote = BigInt(1_000_000);
+      const [accountIdBuy, accountIdSell] = await setupMatchingAccounts(
+        renegade,
+        orderBuy,
+        orderSell,
+        amountBase,
+        amountQuote,
+      );
+
+      // Await until both wallets have an update.
+      await Promise.all([
+        blockUntilUpdate(renegade, accountIdBuy),
+        blockUntilUpdate(renegade, accountIdSell),
+      ]);
+
+      // Assert that the first pair of orders were matched.
+      const orderRemaining1 = new Order({
+        id: orderSell.orderId,
+        baseToken: new Token({ ticker: "WBTC" }),
+        quoteToken: new Token({ ticker: "USDC" }),
+        side: "sell",
+        type: "midpoint",
+        amount: BigInt(4),
+      });
+      expectOrdersEquality(renegade.getOrders(accountIdBuy), {});
+      expectOrdersEquality(renegade.getOrders(accountIdSell), {
+        [orderRemaining1.orderId]: orderRemaining1,
+      });
+
+      // Place the second buy order.
+      await renegade.placeOrder(accountIdBuy, orderBuy);
+
+      // Await until both wallets have an update.
+      await Promise.all([
+        blockUntilUpdate(renegade, accountIdBuy),
+        blockUntilUpdate(renegade, accountIdSell),
+      ]);
+
+      // Assert that the second pair of orders were matched.
+      const orderRemaining2 = new Order({
+        id: orderSell.orderId,
+        baseToken: new Token({ ticker: "WBTC" }),
+        quoteToken: new Token({ ticker: "USDC" }),
+        side: "sell",
+        type: "midpoint",
+        amount: BigInt(3),
+      });
+      expectOrdersEquality(renegade.getOrders(accountIdBuy), {});
+      expectOrdersEquality(renegade.getOrders(accountIdSell), {
+        [orderRemaining2.orderId]: orderRemaining2,
+      });
+
+      // Teardown.
+      await renegade.teardown();
+    },
+  );
+});

--- a/__tests__/order.test.ts
+++ b/__tests__/order.test.ts
@@ -1,46 +1,21 @@
-import { Keychain, Order, OrderId, Renegade, Token } from "../src";
-import { renegadeConfig } from "./utils";
+import { Keychain, Order, Renegade, Token } from "../src";
+import { expectOrdersEquality, renegadeConfig } from "./utils";
 
 // Some test orders.
 const order1 = new Order({
   baseToken: new Token({ ticker: "WETH" }),
   quoteToken: new Token({ ticker: "USDC" }),
   side: "buy",
-  type: "limit",
+  type: "midpoint",
   amount: BigInt(5),
-  price: 2000,
 });
 const order2 = new Order({
   baseToken: new Token({ ticker: "WBTC" }),
   quoteToken: new Token({ ticker: "USDC" }),
   side: "sell",
-  type: "limit",
+  type: "midpoint",
   amount: BigInt(1),
-  price: 30000,
 });
-
-// Equality check for orders, ignoring the timestamp.
-function expectOrderEquality(order1: Order, order2: Order) {
-  expect(order1.orderId).toEqual(order2.orderId);
-  expect(order1.baseToken).toEqual(order2.baseToken);
-  expect(order1.quoteToken).toEqual(order2.quoteToken);
-  expect(order1.side).toEqual(order2.side);
-  expect(order1.type).toEqual(order2.type);
-  expect(order1.amount).toEqual(order2.amount);
-  expect(order1.minimumAmount).toEqual(order2.minimumAmount);
-  expect(order1.price).toEqual(order2.price);
-}
-
-// Equality check for a hashmap of orders, ignoring the timestamp.
-function expectOrdersEquality(
-  orders1: Record<OrderId, Order>,
-  orders2: Record<OrderId, Order>,
-) {
-  expect(Object.keys(orders1).sort()).toEqual(Object.keys(orders2).sort());
-  for (const orderId in orders1) {
-    expectOrderEquality(orders1[orderId], orders2[orderId]);
-  }
-}
 
 describe("Creating and Cancelling Orders", () => {
   test.concurrent(

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 
-import { Keychain, RenegadeConfig } from "../src";
+import { Keychain, Order, OrderId, RenegadeConfig } from "../src";
 
 export const RENEGADE_TEST_DIR = "./temp-test";
 export const renegadeConfig: RenegadeConfig = {
@@ -9,7 +9,7 @@ export const renegadeConfig: RenegadeConfig = {
   relayerWsPort: 4000,
   useInsecureTransport: true,
   verbose: false,
-  taskDelay: 1000,
+  taskDelay: 2500,
 };
 export const globalKeychain = new Keychain({
   skRoot: Buffer.from(
@@ -27,4 +27,27 @@ export function executeTestWithCleanup(test: () => void) {
   test();
   // Clean up after the test.
   fs.rmSync(RENEGADE_TEST_DIR, { recursive: true });
+}
+
+// Equality check for orders, ignoring the timestamp.
+export function expectOrderEquality(order1: Order, order2: Order) {
+  expect(order1.orderId).toEqual(order2.orderId);
+  expect(order1.baseToken).toEqual(order2.baseToken);
+  expect(order1.quoteToken).toEqual(order2.quoteToken);
+  expect(order1.side).toEqual(order2.side);
+  expect(order1.type).toEqual(order2.type);
+  expect(order1.amount).toEqual(order2.amount);
+  expect(order1.minimumAmount).toEqual(order2.minimumAmount);
+  expect(order1.worstPrice).toEqual(order2.worstPrice);
+}
+
+// Equality check for a hashmap of orders, ignoring the timestamp.
+export function expectOrdersEquality(
+  orders1: Record<OrderId, Order>,
+  orders2: Record<OrderId, Order>,
+) {
+  expect(Object.keys(orders1).sort()).toEqual(Object.keys(orders2).sort());
+  for (const orderId in orders1) {
+    expectOrderEquality(orders1[orderId], orders2[orderId]);
+  }
 }

--- a/dist/account.js
+++ b/dist/account.js
@@ -372,7 +372,9 @@ export default class Account {
      * @throws {AccountNotSynced} If the Account has not yet been synced to the relayer.
      */
     get balances() {
-        return this._wallet.balances.reduce((acc, balance) => {
+        return this._wallet.balances
+            .filter((balance) => balance.amount !== BigInt(0))
+            .reduce((acc, balance) => {
             acc[balance.balanceId] = balance;
             return acc;
         }, {});
@@ -383,7 +385,9 @@ export default class Account {
      * @throws {AccountNotSynced} If the Account has not yet been synced to the relayer.
      */
     get orders() {
-        return this._wallet.orders.reduce((acc, order) => {
+        return this._wallet.orders
+            .filter((order) => order.amount !== BigInt(0))
+            .reduce((acc, order) => {
             acc[order.orderId] = order;
             return acc;
         }, {});

--- a/dist/state/order.d.ts
+++ b/dist/state/order.d.ts
@@ -5,20 +5,20 @@ export default class Order {
     readonly baseToken: Token;
     readonly quoteToken: Token;
     readonly side: "buy" | "sell";
-    readonly type: "midpoint" | "limit";
+    readonly type: "midpoint" | "bidirectional";
     readonly amount: bigint;
-    readonly minimumAmount?: bigint;
-    readonly price?: number;
+    readonly minimumAmount: bigint;
+    readonly worstPrice: number;
     readonly timestamp: number;
     constructor(params: {
         id?: OrderId;
         baseToken: Token;
         quoteToken: Token;
         side: "buy" | "sell";
-        type: "midpoint" | "limit";
+        type: "midpoint" | "bidirectional";
         amount: bigint;
         minimumAmount?: bigint;
-        price?: number;
+        worstPrice?: number;
         timestamp?: number;
     });
     pack(): bigint[];

--- a/src/account.ts
+++ b/src/account.ts
@@ -425,10 +425,12 @@ export default class Account {
    */
   @assertSynced
   get balances(): Record<BalanceId, Balance> {
-    return this._wallet.balances.reduce((acc, balance) => {
-      acc[balance.balanceId] = balance;
-      return acc;
-    }, {} as Record<BalanceId, Balance>);
+    return this._wallet.balances
+      .filter((balance) => balance.amount !== BigInt(0))
+      .reduce((acc, balance) => {
+        acc[balance.balanceId] = balance;
+        return acc;
+      }, {} as Record<BalanceId, Balance>);
   }
 
   /**
@@ -438,10 +440,12 @@ export default class Account {
    */
   @assertSynced
   get orders(): Record<OrderId, Order> {
-    return this._wallet.orders.reduce((acc, order) => {
-      acc[order.orderId] = order;
-      return acc;
-    }, {} as Record<OrderId, Order>);
+    return this._wallet.orders
+      .filter((order) => order.amount !== BigInt(0))
+      .reduce((acc, order) => {
+        acc[order.orderId] = order;
+        return acc;
+      }, {} as Record<OrderId, Order>);
   }
 
   /**

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -12,7 +12,8 @@
     "experimentalDecorators": true
   },
   "include": [
-    "./src/**/*.ts"
+    "./src/**/*.ts",
+    "./__tests__/**/*.ts"
   ],
   "exclude": [
     "./node_modules"


### PR DESCRIPTION
### Purpose

Adds `match.test.ts`, a suite of tests that ensure that internal matches are working.

### Testing

The full `renegade-js` test suite works against a `renegade` relayer with a rebase of the `testnet` branch on top of [`chris/balance-augmentation-bug`](https://github.com/renegade-fi/renegade/tree/9be4b8151c4c2714cc610584e6866f7490cf2474).