### PR TITLE
Add types and parse API response for type safety

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,8 @@
 import Renegade, { RenegadeConfig } from "./renegade";
 import { Balance, Fee, Keychain, Order, Token } from "./state";
 import { BalanceId, OrderId, FeeId, AccountId, TaskId, CallbackId, Exchange } from "./types";
+import { ExchangeHealthState, HealthStateEnum as HealthState, PriceReport } from "./types/schema";
 export { Renegade, RenegadeConfig };
 export { Balance, Fee, Keychain, Order, Token };
 export { BalanceId, OrderId, FeeId, AccountId, TaskId, CallbackId, Exchange };
+export { ExchangeHealthState, HealthState, PriceReport };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,8 @@
 import Renegade from "./renegade";
 import { Balance, Fee, Keychain, Order, Token } from "./state";
 import { Exchange, } from "./types";
+import { HealthStateEnum as HealthState, } from "./types/schema";
 export { Renegade };
 export { Balance, Fee, Keychain, Order, Token };
 export { Exchange };
+export { HealthState };

--- a/dist/renegade.d.ts
+++ b/dist/renegade.d.ts
@@ -1,6 +1,7 @@
 import { IRenegadeAccount, IRenegadeBalance, IRenegadeFees, IRenegadeInformation, IRenegadeStreaming, IRenegadeTrading } from "./irenegade";
 import { Balance, Fee, Keychain, Order, Token } from "./state";
 import { AccountId, BalanceId, CallbackId, Exchange, FeeId, OrderId, TaskId } from "./types";
+import { ExchangeHealthState } from "./types/schema";
 import { Priority } from "./utils";
 /**
  * Configuration parameters for initial Renegade object creation.
@@ -51,7 +52,7 @@ export default class Renegade implements IRenegadeAccount, IRenegadeInformation,
      * Ping the relayer to check if it is reachable.
      */
     ping(): Promise<void>;
-    queryExchangeHealthStates(baseToken: Token, quoteToken: Token): Promise<any>;
+    queryExchangeHealthStates(baseToken: Token, quoteToken: Token): Promise<ExchangeHealthState>;
     /**
      * Get the semver of the relayer.
      */

--- a/dist/types/schema.d.ts
+++ b/dist/types/schema.d.ts
@@ -1,0 +1,360 @@
+import { z } from "zod";
+export type PriceReport = z.infer<typeof priceReportSchema>;
+export type ExchangeHealthState = z.infer<typeof exchangeHealthStatesSchema>;
+export declare const HealthStateEnum: z.ZodEnum<["Connecting", "Live", "NoDataReported", "Nominal", "NotEnoughData", "TooMuchDeviation", "TooStale", "Unsupported"]>;
+declare const priceReportSchema: z.ZodObject<{
+    baseToken: z.ZodRecord<z.ZodString, z.ZodString>;
+    exchange: z.ZodNullable<z.ZodEnum<["Binance", "Coinbase", "Kraken", "Okx", "UniswapV3", "Median"]>>;
+    localTimestamp: z.ZodNumber;
+    midpointPrice: z.ZodNumber;
+    quoteToken: z.ZodRecord<z.ZodString, z.ZodString>;
+    reportedTimestamp: z.ZodNullable<z.ZodNumber>;
+    topic: z.ZodOptional<z.ZodString>;
+    type: z.ZodOptional<z.ZodString>;
+    healthState: z.ZodEnum<["Connecting", "Live", "NoDataReported", "Nominal", "NotEnoughData", "TooMuchDeviation", "TooStale", "Unsupported"]>;
+}, "strip", z.ZodTypeAny, {
+    baseToken?: Record<string, string>;
+    exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+    localTimestamp?: number;
+    midpointPrice?: number;
+    quoteToken?: Record<string, string>;
+    reportedTimestamp?: number;
+    topic?: string;
+    type?: string;
+    healthState?: "Connecting" | "Live" | "NoDataReported" | "Nominal" | "NotEnoughData" | "TooMuchDeviation" | "TooStale" | "Unsupported";
+}, {
+    baseToken?: Record<string, string>;
+    exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+    localTimestamp?: number;
+    midpointPrice?: number;
+    quoteToken?: Record<string, string>;
+    reportedTimestamp?: number;
+    topic?: string;
+    type?: string;
+    healthState?: "Connecting" | "Live" | "NoDataReported" | "Nominal" | "NotEnoughData" | "TooMuchDeviation" | "TooStale" | "Unsupported";
+}>;
+export declare const oldExchangeHealthStatesSchema: z.ZodObject<{
+    all_exchanges: z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodObject<{
+        Nominal: z.ZodObject<{
+            baseToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            exchange: z.ZodNullable<z.ZodEnum<["Binance", "Coinbase", "Kraken", "Okx", "UniswapV3", "Median"]>>;
+            localTimestamp: z.ZodNumber;
+            midpointPrice: z.ZodNumber;
+            quoteToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            reportedTimestamp: z.ZodNullable<z.ZodNumber>;
+            topic: z.ZodOptional<z.ZodString>;
+            type: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }>;
+    }, "strip", z.ZodTypeAny, {
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+    }, {
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+    }>, z.ZodEnum<["Connecting", "Live", "NoDataReported", "Nominal", "NotEnoughData", "TooMuchDeviation", "TooStale", "Unsupported"]>]>>;
+    median: z.ZodObject<{
+        DataTooStale: z.ZodOptional<z.ZodTuple<[z.ZodObject<{
+            baseToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            exchange: z.ZodNullable<z.ZodEnum<["Binance", "Coinbase", "Kraken", "Okx", "UniswapV3", "Median"]>>;
+            localTimestamp: z.ZodNumber;
+            midpointPrice: z.ZodNumber;
+            quoteToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            reportedTimestamp: z.ZodNullable<z.ZodNumber>;
+            topic: z.ZodOptional<z.ZodString>;
+            type: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }>, z.ZodNumber], null>>;
+        Nominal: z.ZodOptional<z.ZodObject<{
+            baseToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            exchange: z.ZodNullable<z.ZodEnum<["Binance", "Coinbase", "Kraken", "Okx", "UniswapV3", "Median"]>>;
+            localTimestamp: z.ZodNumber;
+            midpointPrice: z.ZodNumber;
+            quoteToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            reportedTimestamp: z.ZodNullable<z.ZodNumber>;
+            topic: z.ZodOptional<z.ZodString>;
+            type: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }>>;
+        TooMuchDeviation: z.ZodOptional<z.ZodTuple<[z.ZodObject<{
+            baseToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            exchange: z.ZodNullable<z.ZodEnum<["Binance", "Coinbase", "Kraken", "Okx", "UniswapV3", "Median"]>>;
+            localTimestamp: z.ZodNumber;
+            midpointPrice: z.ZodNumber;
+            quoteToken: z.ZodRecord<z.ZodString, z.ZodString>;
+            reportedTimestamp: z.ZodNullable<z.ZodNumber>;
+            topic: z.ZodOptional<z.ZodString>;
+            type: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }>, z.ZodNumber], null>>;
+    }, "strip", z.ZodTypeAny, {
+        DataTooStale?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+        TooMuchDeviation?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+    }, {
+        DataTooStale?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+        TooMuchDeviation?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+    }>;
+}, "strip", z.ZodTypeAny, {
+    all_exchanges?: Record<string, "Connecting" | "Live" | "NoDataReported" | "Nominal" | "NotEnoughData" | "TooMuchDeviation" | "TooStale" | "Unsupported" | {
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+    }>;
+    median?: {
+        DataTooStale?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+        TooMuchDeviation?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+    };
+}, {
+    all_exchanges?: Record<string, "Connecting" | "Live" | "NoDataReported" | "Nominal" | "NotEnoughData" | "TooMuchDeviation" | "TooStale" | "Unsupported" | {
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+    }>;
+    median?: {
+        DataTooStale?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+        Nominal?: {
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        };
+        TooMuchDeviation?: [{
+            baseToken?: Record<string, string>;
+            exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+            localTimestamp?: number;
+            midpointPrice?: number;
+            quoteToken?: Record<string, string>;
+            reportedTimestamp?: number;
+            topic?: string;
+            type?: string;
+        }, number, ...unknown[]];
+    };
+}>;
+declare const exchangeHealthStatesSchema: z.ZodRecord<z.ZodString, z.ZodObject<{
+    baseToken: z.ZodRecord<z.ZodString, z.ZodString>;
+    exchange: z.ZodNullable<z.ZodEnum<["Binance", "Coinbase", "Kraken", "Okx", "UniswapV3", "Median"]>>;
+    localTimestamp: z.ZodNumber;
+    midpointPrice: z.ZodNumber;
+    quoteToken: z.ZodRecord<z.ZodString, z.ZodString>;
+    reportedTimestamp: z.ZodNullable<z.ZodNumber>;
+    topic: z.ZodOptional<z.ZodString>;
+    type: z.ZodOptional<z.ZodString>;
+    healthState: z.ZodEnum<["Connecting", "Live", "NoDataReported", "Nominal", "NotEnoughData", "TooMuchDeviation", "TooStale", "Unsupported"]>;
+}, "strip", z.ZodTypeAny, {
+    baseToken?: Record<string, string>;
+    exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+    localTimestamp?: number;
+    midpointPrice?: number;
+    quoteToken?: Record<string, string>;
+    reportedTimestamp?: number;
+    topic?: string;
+    type?: string;
+    healthState?: "Connecting" | "Live" | "NoDataReported" | "Nominal" | "NotEnoughData" | "TooMuchDeviation" | "TooStale" | "Unsupported";
+}, {
+    baseToken?: Record<string, string>;
+    exchange?: "Binance" | "Coinbase" | "Kraken" | "Okx" | "UniswapV3" | "Median";
+    localTimestamp?: number;
+    midpointPrice?: number;
+    quoteToken?: Record<string, string>;
+    reportedTimestamp?: number;
+    topic?: string;
+    type?: string;
+    healthState?: "Connecting" | "Live" | "NoDataReported" | "Nominal" | "NotEnoughData" | "TooMuchDeviation" | "TooStale" | "Unsupported";
+}>>;
+export declare function parseExchangeHealthStates({ median, all_exchanges, }: z.infer<typeof oldExchangeHealthStatesSchema>): ExchangeHealthState;
+export {};

--- a/dist/types/schema.js
+++ b/dist/types/schema.js
@@ -1,0 +1,103 @@
+import { z } from "zod";
+const ExchangeEnum = z.enum([
+    "Binance",
+    "Coinbase",
+    "Kraken",
+    "Okx",
+    "UniswapV3",
+    "Median",
+]);
+export const HealthStateEnum = z.enum([
+    "Connecting",
+    "Live",
+    "NoDataReported",
+    "Nominal",
+    "NotEnoughData",
+    "TooMuchDeviation",
+    "TooStale",
+    "Unsupported",
+]);
+const oldPriceReportSchema = z.object({
+    baseToken: z.record(z.string()),
+    // TODO: Test this
+    exchange: ExchangeEnum.nullable(),
+    localTimestamp: z.number(),
+    midpointPrice: z.number(),
+    quoteToken: z.record(z.string()),
+    reportedTimestamp: z.number().nullable(),
+    topic: z.string().optional(),
+    type: z.string().optional(),
+});
+const priceReportSchema = z.object({
+    baseToken: z.record(z.string()),
+    exchange: ExchangeEnum.nullable(),
+    localTimestamp: z.number(),
+    midpointPrice: z.number(),
+    quoteToken: z.record(z.string()),
+    reportedTimestamp: z.number().nullable(),
+    topic: z.string().optional(),
+    type: z.string().optional(),
+    healthState: HealthStateEnum,
+});
+const medianSchema = z.object({
+    DataTooStale: z.tuple([oldPriceReportSchema, z.number()]).optional(),
+    Nominal: oldPriceReportSchema.optional(),
+    TooMuchDeviation: z.tuple([oldPriceReportSchema, z.number()]).optional(),
+});
+const allExchangesNominalSchema = z.object({
+    Nominal: oldPriceReportSchema,
+});
+const allExchangesSchema = z.record(allExchangesNominalSchema.or(HealthStateEnum));
+export const oldExchangeHealthStatesSchema = z.object({
+    all_exchanges: allExchangesSchema,
+    median: medianSchema,
+});
+const exchangeHealthStatesSchema = z.record(priceReportSchema);
+function parseMedian(median) {
+    let res;
+    if (median.Nominal) {
+        res = {
+            ...median.Nominal,
+            healthState: HealthStateEnum.enum.Live,
+        };
+        return res;
+    }
+    if (median.DataTooStale) {
+        res = {
+            ...median.DataTooStale[0],
+            healthState: HealthStateEnum.enum.TooStale,
+        };
+        return res;
+    }
+    if (median.TooMuchDeviation) {
+        res = {
+            ...median.TooMuchDeviation[0],
+            healthState: HealthStateEnum.enum.TooMuchDeviation,
+        };
+        return res;
+    }
+}
+function parseExchanges(data) {
+    const isHealthState = HealthStateEnum.safeParse(data);
+    if (isHealthState.success) {
+        return {
+            healthState: isHealthState.data,
+        };
+    }
+    else {
+        return {
+            ...allExchangesNominalSchema.parse(data).Nominal,
+            healthState: HealthStateEnum.enum.Live,
+        };
+    }
+}
+export function parseExchangeHealthStates({ median, all_exchanges, }) {
+    return {
+        [ExchangeEnum.enum.Median]: parseMedian(median),
+        [ExchangeEnum.enum.Binance]: parseExchanges(all_exchanges[ExchangeEnum.enum.Binance]),
+        [ExchangeEnum.enum.Coinbase]: parseExchanges(all_exchanges[ExchangeEnum.enum.Coinbase]),
+        [ExchangeEnum.enum.Kraken]: parseExchanges(all_exchanges[ExchangeEnum.enum.Kraken]),
+        [ExchangeEnum.enum.Okx]: parseExchanges(all_exchanges[ExchangeEnum.enum.Okx]),
+        [ExchangeEnum.enum.UniswapV3]: parseExchanges(all_exchanges[ExchangeEnum.enum.UniswapV3]),
+    };
+}

--- a/dist/utils/fetcher.d.ts
+++ b/dist/utils/fetcher.d.ts
@@ -1,0 +1,9 @@
+import * as fetch from "isomorphic-fetch";
+export type AnyFetcher = (...args: any[]) => any;
+export type Schema<TData> = {
+    parse: (data: unknown) => TData;
+};
+export type ZodFetcher<TFetcher extends AnyFetcher> = <TData>(schema: Schema<TData>, ...args: Parameters<TFetcher>) => Promise<TData>;
+export declare const defaultFetcher: (...args: Parameters<typeof fetch>) => Promise<any>;
+export declare function createZodFetcher(): ZodFetcher<typeof fetch>;
+export declare function createZodFetcher<TFetcher extends AnyFetcher>(fetcher: TFetcher): ZodFetcher<TFetcher>;

--- a/dist/utils/fetcher.js
+++ b/dist/utils/fetcher.js
@@ -1,0 +1,14 @@
+import * as fetch from "isomorphic-fetch";
+export const defaultFetcher = async (...args) => {
+    const response = await fetch(...args);
+    if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+    }
+    return response.json();
+};
+export function createZodFetcher(fetcher = defaultFetcher) {
+    return async (schema, ...args) => {
+        const response = await fetcher(...args);
+        return schema.parse(response.data);
+    };
+}

--- a/dist/utils/index.d.ts
+++ b/dist/utils/index.d.ts
@@ -1,5 +1,6 @@
 import { Keychain, Token } from "../state";
 import { AccountId, CallbackId, Exchange, TaskId } from "../types";
+import { createZodFetcher } from "./fetcher";
 export type TaskJob<R> = Promise<[TaskId, Promise<R>]>;
 export type Priority = number;
 export declare function unimplemented(): never;
@@ -51,3 +52,4 @@ export declare class RenegadeWs {
     releaseCallback(callbackId: CallbackId): Promise<void>;
     teardown(): void;
 }
+export { createZodFetcher };

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -2,6 +2,7 @@ import * as uuid from "uuid";
 import WebSocket from "isomorphic-ws";
 import RenegadeError, { RenegadeErrorType } from "../errors";
 import { RENEGADE_AUTH_EXPIRATION_HEADER, RENEGADE_AUTH_HEADER, } from "../state/utils";
+import { createZodFetcher } from "./fetcher";
 export function unimplemented() {
     throw new Error("unimplemented");
 }
@@ -187,3 +188,4 @@ export class RenegadeWs {
         }
     }
 }
+export { createZodFetcher };

--- a/package.json
+++ b/package.json
@@ -23,14 +23,16 @@
     "lint": "npm run prettier && npm run eslint"
   },
   "dependencies": {
-    "@noble/ed25519": "git+https://github.com/renegade-fi/noble-ed25519#prehashed-context",
+    "@noble/ed25519": "https://github.com/renegade-fi/noble-ed25519#prehashed-context",
     "@noble/hashes": "^1.3.0",
     "axios": "^1.3.5",
     "ffjavascript": "^0.2.60",
+    "isomorphic-fetch": "^3.0.0",
     "isomorphic-ws": "^5.0.0",
     "keccak256": "^1.0.6",
     "uuid": "^9.0.0",
-    "ws": "^8.13.0"
+    "ws": "^8.13.0",
+    "zod": "^3.22.2"
   },
   "devDependencies": {
     "@babel/parser": "^7.21.8",
@@ -48,6 +50,7 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
     "ts-jest": "^29.0.5",
+    "ts-to-zod": "^3.1.3",
     "typescript": "*"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,13 @@ import {
   CallbackId,
   Exchange,
 } from "./types";
+import {
+  ExchangeHealthState,
+  HealthStateEnum as HealthState,
+  PriceReport,
+} from "./types/schema";
 
 export { Renegade, RenegadeConfig };
 export { Balance, Fee, Keychain, Order, Token };
 export { BalanceId, OrderId, FeeId, AccountId, TaskId, CallbackId, Exchange };
+export { ExchangeHealthState, HealthState, PriceReport };

--- a/src/state/wallet.ts
+++ b/src/state/wallet.ts
@@ -177,7 +177,6 @@ export default class Wallet {
     return [blindedPublicShares, privateShares];
   }
 
-  // TODO: Check if order ahas always been empty
   serialize(asBigEndian?: boolean): string {
     const serializedBlindedPublicShares = this.blindedPublicShares.map(
       (share) => "[" + bigIntToLimbsLE(share).join(",") + "]",

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+
+export type PriceReport = z.infer<typeof priceReportSchema>;
+export type ExchangeHealthState = z.infer<typeof exchangeHealthStatesSchema>;
+
+const ExchangeEnum = z.enum([
+  "Binance",
+  "Coinbase",
+  "Kraken",
+  "Okx",
+  "UniswapV3",
+  "Median",
+]);
+
+export const HealthStateEnum = z.enum([
+  "Connecting",
+  "Live",
+  "NoDataReported",
+  "Nominal",
+  "NotEnoughData",
+  "TooMuchDeviation",
+  "TooStale",
+  "Unsupported",
+]);
+
+const oldPriceReportSchema = z.object({
+  baseToken: z.record(z.string()),
+  // TODO: Test this
+  exchange: ExchangeEnum.nullable(),
+  localTimestamp: z.number(),
+  midpointPrice: z.number(),
+  quoteToken: z.record(z.string()),
+  reportedTimestamp: z.number().nullable(),
+  topic: z.string().optional(),
+  type: z.string().optional(),
+});
+
+const priceReportSchema = z.object({
+  baseToken: z.record(z.string()),
+  exchange: ExchangeEnum.nullable(),
+  localTimestamp: z.number(),
+  midpointPrice: z.number(),
+  quoteToken: z.record(z.string()),
+  reportedTimestamp: z.number().nullable(),
+  topic: z.string().optional(),
+  type: z.string().optional(),
+  healthState: HealthStateEnum,
+});
+
+const medianSchema = z.object({
+  DataTooStale: z.tuple([oldPriceReportSchema, z.number()]).optional(),
+  Nominal: oldPriceReportSchema.optional(),
+  TooMuchDeviation: z.tuple([oldPriceReportSchema, z.number()]).optional(),
+});
+
+const allExchangesNominalSchema = z.object({
+  Nominal: oldPriceReportSchema,
+});
+
+const allExchangesSchema = z.record(
+  allExchangesNominalSchema.or(HealthStateEnum),
+);
+
+export const oldExchangeHealthStatesSchema = z.object({
+  all_exchanges: allExchangesSchema,
+  median: medianSchema,
+});
+
+const exchangeHealthStatesSchema = z.record(priceReportSchema);
+
+function parseMedian(median: z.infer<typeof medianSchema>): PriceReport {
+  let res;
+  if (median.Nominal) {
+    res = {
+      ...median.Nominal,
+      healthState: HealthStateEnum.enum.Live,
+    };
+    return res;
+  }
+  if (median.DataTooStale) {
+    res = {
+      ...median.DataTooStale[0],
+      healthState: HealthStateEnum.enum.TooStale,
+    };
+    return res;
+  }
+  if (median.TooMuchDeviation) {
+    res = {
+      ...median.TooMuchDeviation[0],
+      healthState: HealthStateEnum.enum.TooMuchDeviation,
+    };
+    return res;
+  }
+}
+
+function parseExchanges(
+  data: z.infer<typeof allExchangesNominalSchema | typeof HealthStateEnum>,
+): PriceReport {
+  const isHealthState = HealthStateEnum.safeParse(data);
+  if (isHealthState.success) {
+    return {
+      healthState: isHealthState.data,
+    };
+  } else {
+    return {
+      ...allExchangesNominalSchema.parse(data).Nominal,
+      healthState: HealthStateEnum.enum.Live,
+    };
+  }
+}
+
+export function parseExchangeHealthStates({
+  median,
+  all_exchanges,
+}: z.infer<typeof oldExchangeHealthStatesSchema>): ExchangeHealthState {
+  return {
+    [ExchangeEnum.enum.Median]: parseMedian(median),
+    [ExchangeEnum.enum.Binance]: parseExchanges(
+      all_exchanges[ExchangeEnum.enum.Binance],
+    ),
+    [ExchangeEnum.enum.Coinbase]: parseExchanges(
+      all_exchanges[ExchangeEnum.enum.Coinbase],
+    ),
+    [ExchangeEnum.enum.Kraken]: parseExchanges(
+      all_exchanges[ExchangeEnum.enum.Kraken],
+    ),
+    [ExchangeEnum.enum.Okx]: parseExchanges(
+      all_exchanges[ExchangeEnum.enum.Okx],
+    ),
+    [ExchangeEnum.enum.UniswapV3]: parseExchanges(
+      all_exchanges[ExchangeEnum.enum.UniswapV3],
+    ),
+  };
+}

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,0 +1,36 @@
+import * as fetch from "isomorphic-fetch";
+
+export type AnyFetcher = (...args: any[]) => any;
+
+export type Schema<TData> = {
+  parse: (data: unknown) => TData;
+};
+
+export type ZodFetcher<TFetcher extends AnyFetcher> = <TData>(
+  schema: Schema<TData>,
+  ...args: Parameters<TFetcher>
+) => Promise<TData>;
+
+export const defaultFetcher = async (...args: Parameters<typeof fetch>) => {
+  const response = await fetch(...args);
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  return response.json();
+};
+
+export function createZodFetcher(): ZodFetcher<typeof fetch>;
+
+export function createZodFetcher<TFetcher extends AnyFetcher>(
+  fetcher: TFetcher,
+): ZodFetcher<TFetcher>;
+export function createZodFetcher(
+  fetcher: AnyFetcher = defaultFetcher,
+): ZodFetcher<any> {
+  return async (schema, ...args) => {
+    const response = await fetcher(...args);
+    return schema.parse(response.data);
+  };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ import {
   RENEGADE_AUTH_HEADER,
 } from "../state/utils";
 import { AccountId, CallbackId, Exchange, TaskId } from "../types";
+import { createZodFetcher } from "./fetcher";
 
 export type TaskJob<R> = Promise<[TaskId, Promise<R>]>;
 export type Priority = number;
@@ -303,3 +304,5 @@ export class RenegadeWs {
     }
   }
 }
+
+export { createZodFetcher };

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,9 +713,9 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@noble/ed25519@git+https://github.com/renegade-fi/noble-ed25519#prehashed-context":
+"@noble/ed25519@https://github.com/renegade-fi/noble-ed25519#prehashed-context":
   version "1.7.1"
-  resolved "git+https://github.com/renegade-fi/noble-ed25519#dcd9e5541c527e23b07f09db09d3a2c32ff61b2c"
+  resolved "https://github.com/renegade-fi/noble-ed25519#dcd9e5541c527e23b07f09db09d3a2c32ff61b2c"
 
 "@noble/hashes@^1.3.0":
   version "1.3.0"
@@ -742,6 +742,123 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@oclif/command@^1.8.15", "@oclif/command@^1.8.6":
+  version "1.8.36"
+  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.36.tgz#9739b9c268580d064a50887c4597d1b4e86ca8b5"
+  integrity sha512-/zACSgaYGtAQRzc7HjzrlIs14FuEYAZrMOEwicRoUnZVyRunG4+t5iSEeQu0Xy2bgbCD0U1SP/EdeNZSTXRwjQ==
+  dependencies:
+    "@oclif/config" "^1.18.2"
+    "@oclif/errors" "^1.3.6"
+    "@oclif/help" "^1.0.1"
+    "@oclif/parser" "^3.8.17"
+    debug "^4.1.1"
+    semver "^7.5.4"
+
+"@oclif/config@1.18.16":
+  version "1.18.16"
+  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.18.16.tgz#3235d260ab1eb8388ebb6255bca3dd956249d796"
+  integrity sha512-VskIxVcN22qJzxRUq+raalq6Q3HUde7sokB7/xk5TqRZGEKRVbFeqdQBxDWwQeudiJEgcNiMvIFbMQ43dY37FA==
+  dependencies:
+    "@oclif/errors" "^1.3.6"
+    "@oclif/parser" "^3.8.16"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-wsl "^2.1.1"
+    tslib "^2.6.1"
+
+"@oclif/config@1.18.2":
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.18.2.tgz#5bfe74a9ba6a8ca3dceb314a81bd9ce2e15ebbfe"
+  integrity sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==
+  dependencies:
+    "@oclif/errors" "^1.3.3"
+    "@oclif/parser" "^3.8.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-wsl "^2.1.1"
+    tslib "^2.0.0"
+
+"@oclif/config@^1.17.1", "@oclif/config@^1.18.2":
+  version "1.18.17"
+  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.18.17.tgz#00aa4049da27edca8f06fc106832d9f0f38786a5"
+  integrity sha512-k77qyeUvjU8qAJ3XK3fr/QVAqsZO8QOBuESnfeM5HHtPNLSyfVcwiMM2zveSW5xRdLSG3MfV8QnLVkuyCL2ENg==
+  dependencies:
+    "@oclif/errors" "^1.3.6"
+    "@oclif/parser" "^3.8.17"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-wsl "^2.1.1"
+    tslib "^2.6.1"
+
+"@oclif/errors@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.5.tgz#a1e9694dbeccab10fe2fe15acb7113991bed636c"
+  integrity sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==
+  dependencies:
+    clean-stack "^3.0.0"
+    fs-extra "^8.1"
+    indent-string "^4.0.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+"@oclif/errors@1.3.6", "@oclif/errors@^1.3", "@oclif/errors@^1.3.3", "@oclif/errors@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.6.tgz#e8fe1fc12346cb77c4f274e26891964f5175f75d"
+  integrity sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==
+  dependencies:
+    clean-stack "^3.0.0"
+    fs-extra "^8.1"
+    indent-string "^4.0.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+"@oclif/help@^1.0.1":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@oclif/help/-/help-1.0.15.tgz#5e36e576b8132a4906d2662204ad9de7ece87e8f"
+  integrity sha512-Yt8UHoetk/XqohYX76DfdrUYLsPKMc5pgkzsZVHDyBSkLiGRzujVaGZdjr32ckVZU9q3a47IjhWxhip7Dz5W/g==
+  dependencies:
+    "@oclif/config" "1.18.16"
+    "@oclif/errors" "1.3.6"
+    chalk "^4.1.2"
+    indent-string "^4.0.0"
+    lodash "^4.17.21"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    widest-line "^3.1.0"
+    wrap-ansi "^6.2.0"
+
+"@oclif/linewrap@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
+  integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
+
+"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.16", "@oclif/parser@^3.8.17":
+  version "3.8.17"
+  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.17.tgz#e1ce0f29b22762d752d9da1c7abd57ad81c56188"
+  integrity sha512-l04iSd0xoh/16TGVpXb81Gg3z7tlQGrEup16BrVLsZBK6SEYpYHRJZnM32BwZrHI97ZSFfuSwVlzoo6HdsaK8A==
+  dependencies:
+    "@oclif/errors" "^1.3.6"
+    "@oclif/linewrap" "^1.0.0"
+    chalk "^4.1.0"
+    tslib "^2.6.2"
+
+"@oclif/plugin-help@^3.2.7":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-3.3.1.tgz#36adb4e0173f741df409bb4b69036d24a53bfb24"
+  integrity sha512-QuSiseNRJygaqAdABYFWn/H1CwIZCp9zp/PLid6yXvy6VcQV7OenEFF5XuYaCvSARe2Tg9r8Jqls5+fw1A9CbQ==
+  dependencies:
+    "@oclif/command" "^1.8.15"
+    "@oclif/config" "1.18.2"
+    "@oclif/errors" "1.3.5"
+    "@oclif/help" "^1.0.1"
+    chalk "^4.1.2"
+    indent-string "^4.0.0"
+    lodash "^4.17.21"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    widest-line "^3.1.0"
+    wrap-ansi "^6.2.0"
 
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
@@ -972,6 +1089,13 @@
     "@typescript-eslint/types" "5.59.6"
     eslint-visitor-keys "^3.3.0"
 
+"@typescript/vfs@^1.3.5":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.5.0.tgz#ed942922724f9ace8c07c80b006c47e5e3833218"
+  integrity sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==
+  dependencies:
+    debug "^4.1.1"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -1023,7 +1147,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -1087,10 +1211,20 @@ array.prototype.flatmap@^1.3.1:
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
+async@^3.2.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
@@ -1176,6 +1310,20 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 bn.js@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
@@ -1189,7 +1337,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1225,6 +1373,14 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 buffer@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
@@ -1248,7 +1404,7 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -1268,6 +1424,11 @@ caniuse-lite@^1.0.30001449:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz#d882d1a34d89c11aea53b8cdc791931bdab5fe1b"
   integrity sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==
 
+case@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
+  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1277,7 +1438,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1290,6 +1451,26 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chokidar@^3.5.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 ci-info@^3.2.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
@@ -1300,6 +1481,30 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+clean-stack@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
+  integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
+  dependencies:
+    escape-string-regexp "4.0.0"
+
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
+cli-spinners@^2.5.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.0.tgz#5881d0ad96381e117bbe07ad91f2008fe6ffd8db"
+  integrity sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
@@ -1308,6 +1513,11 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -1381,7 +1591,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1402,6 +1612,13 @@ deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+defaults@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"
+  integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
+  dependencies:
+    clone "^1.0.2"
 
 define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   version "1.2.0"
@@ -1539,6 +1756,11 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -1548,11 +1770,6 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
-escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-config-prettier@^8.8.0:
   version "8.8.0"
@@ -1727,6 +1944,11 @@ eslint@^8.0.1:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^9.5.2:
   version "9.5.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.2.tgz#e994e7dc33a082a7a82dceaf12883a829353215b"
@@ -1801,6 +2023,15 @@ expect@^29.0.0, expect@^29.5.0:
     jest-message-util "^29.5.0"
     jest-util "^29.5.0"
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1849,6 +2080,13 @@ ffjavascript@^0.2.60:
     wasmbuilder "0.0.16"
     wasmcurves "0.2.2"
     web-worker "^1.2.0"
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -1914,6 +2152,25 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+fs-extra@^8.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1923,6 +2180,11 @@ fsevents@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -1982,7 +2244,7 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2027,7 +2289,7 @@ globalthis@^1.0.3:
   dependencies:
     define-properties "^1.1.3"
 
-globby@^11.1.0:
+globby@^11.0.1, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -2046,7 +2308,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.2.9:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2112,7 +2374,14 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-ieee754@^1.2.1:
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -2143,6 +2412,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2151,10 +2425,31 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inquirer@^8.2.0:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.6.tgz#733b74888195d8d400a67ac332011b5fae5ea562"
+  integrity sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^6.0.1"
 
 internal-slot@^1.0.5:
   version "1.0.5"
@@ -2186,6 +2481,13 @@ is-bigint@^1.0.1:
   dependencies:
     has-bigints "^1.0.1"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
@@ -2213,6 +2515,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -2228,12 +2535,17 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -2251,6 +2563,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-observable@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-2.1.0.tgz#5c8d733a0b201c80dff7bb7c0df58c6a255c7c69"
+  integrity sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==
 
 is-path-inside@^3.0.3:
   version "3.0.3"
@@ -2302,6 +2619,11 @@ is-typed-array@^1.1.10, is-typed-array@^1.1.9:
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
 
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
@@ -2309,10 +2631,25 @@ is-weakref@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 isomorphic-ws@^5.0.0:
   version "5.0.0"
@@ -2784,6 +3121,22 @@ json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 keccak256@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/keccak256/-/keccak256-1.0.6.tgz#dd32fb771558fed51ce4e45a035ae7515573da58"
@@ -2854,6 +3207,14 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -2867,6 +3228,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -2944,6 +3310,11 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
@@ -2958,6 +3329,13 @@ node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
+node-fetch@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp-build@^4.2.0:
   version "4.6.0"
@@ -2974,7 +3352,7 @@ node-releases@^2.0.8:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
   integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -3015,6 +3393,11 @@ object.values@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
+observable-fns@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/observable-fns/-/observable-fns-0.6.1.tgz#636eae4fdd1132e88c0faf38d33658cc79d87e37"
+  integrity sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3022,7 +3405,7 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.2:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -3040,6 +3423,26 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ora@^5.4.0, ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -3121,7 +3524,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3142,6 +3545,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 prettier@^2.8.7:
   version "2.8.8"
@@ -3190,7 +3598,7 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-readable-stream@^3.6.0:
+readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -3198,6 +3606,13 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
 
 regexp.prototype.flags@^1.4.3:
   version "1.5.0"
@@ -3249,6 +3664,14 @@ resolve@^1.20.0, resolve@^1.22.1:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -3261,12 +3684,24 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@^7.4.0, rxjs@^7.5.5:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-buffer@~5.2.0:
   version "5.2.1"
@@ -3282,6 +3717,11 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 semver@7.x, semver@^7.0.0, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
@@ -3293,6 +3733,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -3315,7 +3762,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.3, signal-exit@^3.0.7:
+signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -3368,7 +3815,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3478,6 +3925,37 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+threads@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/threads/-/threads-1.7.0.tgz#d9e9627bfc1ef22ada3b733c2e7558bbe78e589c"
+  integrity sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==
+  dependencies:
+    callsites "^3.1.0"
+    debug "^4.2.0"
+    is-observable "^2.1.0"
+    observable-fns "^0.6.1"
+  optionalDependencies:
+    tiny-worker ">= 2"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+"tiny-worker@>= 2":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tiny-worker/-/tiny-worker-2.3.0.tgz#715ae34304c757a9af573ae9a8e3967177e6011e"
+  integrity sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==
+  dependencies:
+    esm "^3.2.25"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -3495,6 +3973,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-jest@^29.0.5:
   version "29.1.0"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.0.tgz#4a9db4104a49b76d2b368ea775b6c9535c603891"
@@ -3508,6 +3991,33 @@ ts-jest@^29.0.5:
     make-error "1.x"
     semver "7.x"
     yargs-parser "^21.0.1"
+
+ts-to-zod@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/ts-to-zod/-/ts-to-zod-3.1.3.tgz#ecbc3d7448d6f39ac09854a413036bdedf3744dd"
+  integrity sha512-zsKldi4VTcjsE8hkxLkjT4OZkSK7vmFeV/rZ2SAR0FlntesMSJwfIbQAAe7vuQ4DBt3VbaVB0M5FBglLNbcmLQ==
+  dependencies:
+    "@oclif/command" "^1.8.6"
+    "@oclif/config" "^1.17.1"
+    "@oclif/errors" "^1.3"
+    "@oclif/plugin-help" "^3.2.7"
+    "@typescript/vfs" "^1.3.5"
+    async "^3.2.0"
+    case "^1.6.3"
+    chokidar "^3.5.1"
+    fs-extra "^9.1.0"
+    inquirer "^8.2.0"
+    lodash "^4.17.21"
+    lz-string "^1.4.4"
+    ora "^5.4.0"
+    prettier "2.2.1"
+    rxjs "^7.4.0"
+    slash "^3.0.0"
+    threads "^1.7.0"
+    tslib "^2.3.1"
+    tsutils "^3.21.0"
+    typescript "^4.5.2"
+    zod "^3.11.6"
 
 tsconfig-paths@^3.14.1:
   version "3.14.2"
@@ -3523,6 +4033,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.6.1, tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -3567,6 +4082,11 @@ typescript@*:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
+typescript@^4.5.2:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -3576,6 +4096,16 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 update-browserslist-db@^1.0.10:
   version "1.0.11"
@@ -3630,10 +4160,35 @@ wasmcurves@0.2.2:
   dependencies:
     wasmbuilder "0.0.16"
 
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
+  dependencies:
+    defaults "^1.0.3"
+
 web-worker@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.2.0.tgz#5d85a04a7fbc1e7db58f66595d7a3ac7c9c180da"
   integrity sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-fetch@^3.4.1:
+  version "3.6.18"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.18.tgz#2f640cdee315abced7daeaed2309abd1e44e62d4"
+  integrity sha512-ltN7j66EneWn5TFDO4L9inYC1D+Czsxlrw2SalgjMmEMkLfA5SIZxEFdE6QtHFiiM6Q7WL32c7AkI3w6yxM84Q==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -3665,10 +4220,26 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+widest-line@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
+  integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
+  dependencies:
+    string-width "^4.0.0"
+
 word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -3734,3 +4305,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.11.6, zod@^3.22.2:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.2.tgz#3add8c682b7077c05ac6f979fea6998b573e157b"
+  integrity sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==


### PR DESCRIPTION
This PR uses `zod` to generate schemas and parse API responses (`queryExchangeHealthStates`) to ensure type safety. Typescript types are inferred from these schemas, and exported for use in the frontend. API responses are also parsed to be more easily used by the frontend.