### PR TITLE
Use existing WS connection to receive Completed tasks

### DIFF
--- a/dist/account.d.ts
+++ b/dist/account.d.ts
@@ -17,7 +17,7 @@ export default class Account {
     private _ws;
     private _wallet;
     private _isSynced;
-    constructor(keychain: Keychain, relayerHttpUrl: string, relayerWsUrl: string, verbose?: boolean);
+    constructor(keychain: Keychain, relayerHttpUrl: string, relayerWsUrl: string, verbose?: boolean, ws?: RenegadeWs);
     /**
      * Reset the Wallet to its initial state by clearing its balances, orders, and
      * fees. Resets are useful in the case of desync from the relayer, allowing us

--- a/dist/account.js
+++ b/dist/account.js
@@ -42,12 +42,13 @@ function assertSynced(_target, _propertyKey, descriptor) {
  * including streaming Wallet events in real-time from the relayer.
  */
 export default class Account {
-    constructor(keychain, relayerHttpUrl, relayerWsUrl, verbose) {
+    constructor(keychain, relayerHttpUrl, relayerWsUrl, verbose, ws) {
         this._relayerHttpUrl = relayerHttpUrl;
         this._relayerWsUrl = relayerWsUrl;
         this._verbose = verbose || false;
         this._reset(keychain);
         this._isSynced = false;
+        this._ws = ws;
     }
     /**
      * Reset the Wallet to its initial state by clearing its balances, orders, and
@@ -140,7 +141,7 @@ export default class Account {
         else {
             // The Wallet is not present in on-chain state, so we need to create it.
             taskId = await this._createNewWallet();
-            const taskPromise = new RenegadeWs(this._relayerWsUrl, this._verbose)
+            const taskPromise = this._ws
                 .awaitTaskCompletion(taskId)
                 .then(() => this._setupWebSocket())
                 .then(() => {

--- a/dist/renegade.js
+++ b/dist/renegade.js
@@ -180,7 +180,7 @@ export default class Renegade {
     // | IRenegadeAccount Implementation |
     // -----------------------------------
     registerAccount(keychain) {
-        const account = new Account(keychain, this.relayerHttpUrl, this.relayerWsUrl, this._verbose);
+        const account = new Account(keychain, this.relayerHttpUrl, this.relayerWsUrl, this._verbose, this._ws);
         const accountId = account.accountId;
         if (this._registeredAccounts[accountId]) {
             throw new RenegadeError(RenegadeErrorType.AccountAlreadyRegistered);

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -119,11 +119,10 @@ export class RenegadeWs {
                     console.log(`[WebSocket] New task state for ${taskId}: ${parsedMessage.event.state}`);
                 }
                 if (parsedMessage.event.state === "Completed") {
-                    resolve();
+                    return this._subscribeToTopic(topic).then(() => resolve());
                 }
             });
         });
-        await this._subscribeToTopic(topic);
         return taskCompletionPromise;
     }
     async registerAccountCallback(callback, accountId, keychain, priority) {

--- a/src/account.ts
+++ b/src/account.ts
@@ -65,12 +65,14 @@ export default class Account {
     relayerHttpUrl: string,
     relayerWsUrl: string,
     verbose?: boolean,
+    ws?: RenegadeWs,
   ) {
     this._relayerHttpUrl = relayerHttpUrl;
     this._relayerWsUrl = relayerWsUrl;
     this._verbose = verbose || false;
     this._reset(keychain);
     this._isSynced = false;
+    this._ws = ws;
   }
 
   /**
@@ -174,7 +176,7 @@ export default class Account {
     } else {
       // The Wallet is not present in on-chain state, so we need to create it.
       taskId = await this._createNewWallet();
-      const taskPromise = new RenegadeWs(this._relayerWsUrl, this._verbose)
+      const taskPromise = this._ws
         .awaitTaskCompletion(taskId)
         .then(() => this._setupWebSocket())
         .then(() => {

--- a/src/renegade.ts
+++ b/src/renegade.ts
@@ -282,6 +282,7 @@ export default class Renegade
       this.relayerHttpUrl,
       this.relayerWsUrl,
       this._verbose,
+      this._ws,
     );
     const accountId = account.accountId;
     if (this._registeredAccounts[accountId]) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -160,12 +160,11 @@ export class RenegadeWs {
             );
           }
           if (parsedMessage.event.state === "Completed") {
-            resolve();
+            return this._subscribeToTopic(topic).then(() => resolve());
           }
         },
       );
     });
-    await this._subscribeToTopic(topic);
     return taskCompletionPromise;
   }
 


### PR DESCRIPTION
This PR addresses the issue of the new WebSocket connection created during the create-wallet task did not receive the event indicating that the create-wallet task completed relayer-side, resulting in the function never resolving. This happened even though the WebSocket connection that exists as part of the Renegade class instantiation did receive these event messages. To solve this, the the WebSocket object within the Renegade class is used temporarily while the create-wallet task completes. 