### PR TITLE
Add manual wallet fetch method

### DIFF
--- a/dist/account.d.ts
+++ b/dist/account.d.ts
@@ -66,6 +66,11 @@ export default class Account {
      */
     private _queryRelayerForWallet;
     /**
+     * Manually fetch the latest Wallet state from the relayer. This is useful if
+     * we want to force a refresh of the Wallet state.
+     */
+    queryWallet(): Promise<void>;
+    /**
      * Query the on-chain state to lookup the Wallet corresponding to this
      * AccountId.
      *

--- a/dist/account.js
+++ b/dist/account.js
@@ -193,6 +193,13 @@ export default class Account {
         }
     }
     /**
+     * Manually fetch the latest Wallet state from the relayer. This is useful if
+     * we want to force a refresh of the Wallet state.
+     */
+    async queryWallet() {
+        this._wallet = await this._queryRelayerForWallet();
+    }
+    /**
      * Query the on-chain state to lookup the Wallet corresponding to this
      * AccountId.
      *

--- a/dist/renegade.d.ts
+++ b/dist/renegade.d.ts
@@ -54,6 +54,7 @@ export default class Renegade implements IRenegadeAccount, IRenegadeInformation,
     ping(): Promise<void>;
     queryExchangeHealthStates(baseToken: Token, quoteToken: Token): Promise<ExchangeHealthState>;
     queryOrders(): Promise<any>;
+    queryWallet(accountId: AccountId): Promise<void>;
     /**
      * Get the semver of the relayer.
      */

--- a/dist/renegade.js
+++ b/dist/renegade.js
@@ -167,6 +167,11 @@ export default class Renegade {
         }
         return response;
     }
+    async queryWallet(accountId) {
+        const account = this._lookupAccount(accountId);
+        console.log("Fetching new wallet");
+        return await account.queryWallet();
+    }
     /**
      * Get the semver of the relayer.
      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/renegade-js",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Typescript bindings for the Renegade relayer API.",
   "author": "Christopher Bender <chris@renegade.fi>",
   "repository": "https://github.com/renegade-fi/renegade-js",

--- a/src/account.ts
+++ b/src/account.ts
@@ -233,6 +233,14 @@ export default class Account {
   }
 
   /**
+   * Manually fetch the latest Wallet state from the relayer. This is useful if
+   * we want to force a refresh of the Wallet state.
+   */
+  async queryWallet(): Promise<void> {
+    this._wallet = await this._queryRelayerForWallet();
+  }
+
+  /**
    * Query the on-chain state to lookup the Wallet corresponding to this
    * AccountId.
    *

--- a/src/renegade.ts
+++ b/src/renegade.ts
@@ -253,6 +253,12 @@ export default class Renegade
     return response;
   }
 
+  async queryWallet(accountId: AccountId): Promise<void> {
+    const account = this._lookupAccount(accountId);
+    console.log("Fetching new wallet");
+    return await account.queryWallet();
+  }
+
   /**
    * Get the semver of the relayer.
    */


### PR DESCRIPTION
This PR adds a function that exposes the fetch wallet endpoint to the client, to manually request the relayer for the latest contents of the wallet.