### PR TITLE
Attempt to place order before modifying order in modifyOrPlaceOrder

### DIFF
--- a/dist/account.js
+++ b/dist/account.js
@@ -358,17 +358,17 @@ export default class Account {
             return acc;
         }, {});
         const zeroOrders = findZeroOrders(orders);
-        if (Object.keys(this.orders).length === 5 && zeroOrders.length === 0) {
-            return new Promise((_, reject) => {
-                reject(new RenegadeError(RenegadeErrorType.MaxOrders));
-            });
+        if (Object.keys(this.orders).length < 5) {
+            return await this.placeOrder(order);
         }
-        if (zeroOrders.length > 0) {
+        else if (zeroOrders.length > 0) {
             const randomOrderId = zeroOrders[Math.floor(Math.random() * zeroOrders.length)];
             return await this.modifyOrder(randomOrderId, order);
         }
         else {
-            return await this.placeOrder(order);
+            return new Promise((_, reject) => {
+                reject(new RenegadeError(RenegadeErrorType.MaxOrders));
+            });
         }
     }
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/renegade-js",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Typescript bindings for the Renegade relayer API.",
   "author": "Christopher Bender <chris@renegade.fi>",
   "repository": "https://github.com/renegade-fi/renegade-js",

--- a/src/account.ts
+++ b/src/account.ts
@@ -411,17 +411,16 @@ export default class Account {
       return acc;
     }, {} as Record<OrderId, Order>);
     const zeroOrders = findZeroOrders(orders);
-    if (Object.keys(this.orders).length === 5 && zeroOrders.length === 0) {
-      return new Promise((_, reject) => {
-        reject(new RenegadeError(RenegadeErrorType.MaxOrders));
-      });
-    }
-    if (zeroOrders.length > 0) {
+    if (Object.keys(this.orders).length < 5) {
+      return await this.placeOrder(order);
+    } else if (zeroOrders.length > 0) {
       const randomOrderId =
         zeroOrders[Math.floor(Math.random() * zeroOrders.length)];
       return await this.modifyOrder(randomOrderId, order);
     } else {
-      return await this.placeOrder(order);
+      return new Promise((_, reject) => {
+        reject(new RenegadeError(RenegadeErrorType.MaxOrders));
+      });
     }
   }
 


### PR DESCRIPTION
This PR updates the `modifyOrPlaceOrder` function so that it attempts to place order before modifying order, so that a wallet's order book gets filled with order IDs instead of having one that is constantly modified (due to https://github.com/renegade-fi/renegade/pull/227)