### PR TITLE
Add updateLocked field to Wallet to mirror relayer

### DIFF
--- a/dist/account.d.ts
+++ b/dist/account.d.ts
@@ -168,4 +168,8 @@ export default class Account {
      * Getter for the underlying RenegadeWs.
      */
     get ws(): RenegadeWs;
+    /**
+     * Getter for the state of the update lock.
+     */
+    get isLocked(): boolean;
 }

--- a/dist/account.js
+++ b/dist/account.js
@@ -456,6 +456,12 @@ export default class Account {
     get ws() {
         return this._ws;
     }
+    /**
+     * Getter for the state of the update lock.
+     */
+    get isLocked() {
+        return this._wallet.updateLocked;
+    }
 }
 __decorate([
     assertSynced

--- a/dist/renegade.d.ts
+++ b/dist/renegade.d.ts
@@ -71,6 +71,7 @@ export default class Renegade implements IRenegadeAccount, IRenegadeInformation,
     getOrders(accountId: AccountId): Record<OrderId, Order>;
     getFees(accountId: AccountId): Record<FeeId, Fee>;
     getKeychain(accountId: AccountId): Keychain;
+    getIsLocked(accountId: AccountId): boolean;
     deposit(accountId: AccountId, mint: Token, amount: bigint): Promise<void>;
     private _depositTaskJob;
     withdraw(accountId: AccountId, mint: Token, amount: bigint): Promise<void>;

--- a/dist/renegade.js
+++ b/dist/renegade.js
@@ -242,6 +242,10 @@ export default class Renegade {
         const account = this._lookupAccount(accountId);
         return account.keychain;
     }
+    getIsLocked(accountId) {
+        const account = this._lookupAccount(accountId);
+        return account.isLocked;
+    }
     // -----------------------------------
     // | IRenegadeBalance Implementation |
     // -----------------------------------
@@ -392,6 +396,9 @@ __decorate([
 __decorate([
     assertNotTornDown
 ], Renegade.prototype, "getKeychain", null);
+__decorate([
+    assertNotTornDown
+], Renegade.prototype, "getIsLocked", null);
 __decorate([
     assertNotTornDown
 ], Renegade.prototype, "deposit", null);

--- a/dist/state/wallet.d.ts
+++ b/dist/state/wallet.d.ts
@@ -14,6 +14,7 @@ export default class Wallet {
     readonly privateBlinder: bigint;
     readonly blindedPublicShares: bigint[];
     readonly privateShares: bigint[];
+    readonly updateLocked: boolean;
     constructor(params: {
         id?: WalletId;
         balances: Balance[];
@@ -21,6 +22,7 @@ export default class Wallet {
         fees: Fee[];
         keychain: Keychain;
         blinder: bigint;
+        updateLocked?: boolean;
     });
     getBlinders(): [bigint, bigint, bigint];
     packBalances(): bigint[];

--- a/dist/state/wallet.js
+++ b/dist/state/wallet.js
@@ -24,6 +24,7 @@ const SHARES_PER_WALLET = MAX_BALANCES * SHARES_PER_BALANCE +
     1;
 export default class Wallet {
     constructor(params) {
+        this.updateLocked = false;
         this.walletId =
             params.id ||
                 generateId(Buffer.from(params.keychain.keyHierarchy.root.publicKey.buffer));
@@ -34,6 +35,7 @@ export default class Wallet {
         [this.blinder, this.privateBlinder, this.publicBlinder] =
             this.getBlinders();
         [this.blindedPublicShares, this.privateShares] = this.deriveShares();
+        this.updateLocked = params.updateLocked || false;
     }
     getBlinders() {
         // TODO: Generate seed from Ethereuem private key
@@ -121,7 +123,8 @@ export default class Wallet {
       "key_chain": ${this.keychain.serialize(asBigEndian)},
       "blinder": [${bigIntToLimbsLE(this.blinder).join(",")}],
       "blinded_public_shares": [${serializedBlindedPublicShares.join(",")}],
-      "private_shares": [${serializedPrivateShares.join(",")}]
+      "private_shares": [${serializedPrivateShares.join(",")}],
+      "update_locked": false
     }`.replace(/[\s\n]/g, "");
     }
     static deserialize(serializedWallet, asBigEndian) {
@@ -131,6 +134,15 @@ export default class Wallet {
         const fees = serializedWallet.fees.map((f) => Fee.deserialize(f));
         const keychain = Keychain.deserialize(serializedWallet.key_chain, asBigEndian);
         const blinder = limbsToBigIntLE(serializedWallet.blinder);
-        return new Wallet({ id, balances, orders, fees, keychain, blinder });
+        const updateLocked = serializedWallet.update_locked;
+        return new Wallet({
+            id,
+            balances,
+            orders,
+            fees,
+            keychain,
+            blinder,
+            updateLocked,
+        });
     }
 }

--- a/src/account.ts
+++ b/src/account.ts
@@ -519,4 +519,11 @@ export default class Account {
   get ws(): RenegadeWs {
     return this._ws;
   }
+
+  /**
+   * Getter for the state of the update lock.
+   */
+  get isLocked(): boolean {
+    return this._wallet.updateLocked;
+  }
 }

--- a/src/renegade.ts
+++ b/src/renegade.ts
@@ -365,6 +365,12 @@ export default class Renegade
     return account.keychain;
   }
 
+  @assertNotTornDown
+  getIsLocked(accountId: AccountId): boolean {
+    const account = this._lookupAccount(accountId);
+    return account.isLocked;
+  }
+
   // -----------------------------------
   // | IRenegadeBalance Implementation |
   // -----------------------------------

--- a/src/state/wallet.ts
+++ b/src/state/wallet.ts
@@ -46,6 +46,7 @@ export default class Wallet {
   public readonly privateBlinder: bigint;
   public readonly blindedPublicShares: bigint[];
   public readonly privateShares: bigint[];
+  public readonly updateLocked: boolean = false;
   constructor(params: {
     id?: WalletId;
     balances: Balance[];
@@ -53,6 +54,7 @@ export default class Wallet {
     fees: Fee[];
     keychain: Keychain;
     blinder: bigint;
+    updateLocked?: boolean;
   }) {
     this.walletId =
       params.id ||
@@ -66,6 +68,7 @@ export default class Wallet {
     [this.blinder, this.privateBlinder, this.publicBlinder] =
       this.getBlinders();
     [this.blindedPublicShares, this.privateShares] = this.deriveShares();
+    this.updateLocked = params.updateLocked || false;
   }
 
   getBlinders(): [bigint, bigint, bigint] {
@@ -192,7 +195,8 @@ export default class Wallet {
       "key_chain": ${this.keychain.serialize(asBigEndian)},
       "blinder": [${bigIntToLimbsLE(this.blinder).join(",")}],
       "blinded_public_shares": [${serializedBlindedPublicShares.join(",")}],
-      "private_shares": [${serializedPrivateShares.join(",")}]
+      "private_shares": [${serializedPrivateShares.join(",")}],
+      "update_locked": false
     }`.replace(/[\s\n]/g, "");
   }
 
@@ -210,6 +214,15 @@ export default class Wallet {
       asBigEndian,
     );
     const blinder = limbsToBigIntLE(serializedWallet.blinder);
-    return new Wallet({ id, balances, orders, fees, keychain, blinder });
+    const updateLocked = serializedWallet.update_locked;
+    return new Wallet({
+      id,
+      balances,
+      orders,
+      fees,
+      keychain,
+      blinder,
+      updateLocked,
+    });
   }
 }


### PR DESCRIPTION
This PR reflects changes in the relayer of adding an updateLocked field to the Wallet object.